### PR TITLE
Documentation: Corrected wrong reference to ADWIN

### DIFF
--- a/src/skmultiflow/drift_detection/ddm.py
+++ b/src/skmultiflow/drift_detection/ddm.py
@@ -48,7 +48,7 @@ class DDM(BaseDriftDetector):
     >>> # increase in error rate
     >>> for i in range(999, 1500):
     ...     data_stream[i] = 0
-    >>> # Adding stream elements to ADWIN and verifying if drift occurred
+    >>> # Adding stream elements to DDM and verifying if drift occurred
     >>> for i in range(2000):
     ...     ddm.add_element(data_stream[i])
     ...     if ddm.detected_warning_zone():

--- a/src/skmultiflow/drift_detection/eddm.py
+++ b/src/skmultiflow/drift_detection/eddm.py
@@ -44,7 +44,7 @@ class EDDM(BaseDriftDetector):
     >>> # increase in error rate
     >>> for i in range(999, 1500):
     ...     data_stream[i] = 0
-    >>> # Adding stream elements to ADWIN and verifying if drift occurred
+    >>> # Adding stream elements to EDDM and verifying if drift occurred
     >>> for i in range(2000):
     ...     eddm.add_element(data_stream[i])
     ...     if eddm.detected_warning_zone():

--- a/src/skmultiflow/drift_detection/page_hinkley.py
+++ b/src/skmultiflow/drift_detection/page_hinkley.py
@@ -34,7 +34,7 @@ class PageHinkley(BaseDriftDetector):
     >>> # Changing the data concept from index 999 to 2000
     >>> for i in range(999, 2000):
     ...     data_stream[i] = np.random.randint(4, high=8)
-    >>> # Adding stream elements to ADWIN and verifying if drift occurred
+    >>> # Adding stream elements to the PageHinkley drift detector and verifying if drift occurred
     >>> for i in range(2000):
     ...     ph.add_element(data_stream[i])
     ...     if ph.detected_change():


### PR DESCRIPTION
Hey, I just noted some wrong references to ADWIN in the examples given in the documentation of the drift detection algorithms.

Changes proposed in this pull request:
- Remove wrong reference to ADWIN and refer to the correct algorithm.


@scikit-multiflow/scikit-multiflow-repo-admins
