### PR TITLE
Add result weight=1.0 in all methods add_result

### DIFF
--- a/src/skmultiflow/metrics/measure_collection.py
+++ b/src/skmultiflow/metrics/measure_collection.py
@@ -83,9 +83,9 @@ class ClassificationMeasurements(BaseObject):
         self.sample_count += weight
 
         if self.get_majority_class() == y_true:
-            self.majority_classifier = self.majority_classifier + weight
+            self.majority_classifier += weight
         if self.last_true_label == y_true:
-            self.correct_no_change = self.correct_no_change + weight
+            self.correct_no_change += weight
 
         self.last_true_label = y_true
         self.last_prediction = y_pred
@@ -359,19 +359,19 @@ class WindowClassificationMeasurements(BaseObject):
 
         # Verify if it's needed to decrease the majority_classifier count
         if (self.get_majority_class() == y_true) and (self.get_majority_class() is not None):
-            self.majority_classifier += 1
+            self.majority_classifier += weight
             self.majority_classifier_correction.add_element([-1])
         else:
             self.majority_classifier_correction.add_element([0])
 
         # Verify if it's needed to decrease the correct_no_change
         if (self.last_true_label == y_true) and (self.last_true_label is not None):
-            self.correct_no_change += 1
+            self.correct_no_change += weight
             self.correct_no_change_correction.add_element([-1])
         else:
             self.correct_no_change_correction.add_element([0])
 
-        self.confusion_matrix.update(true_y, pred)
+        self.confusion_matrix.update(true_y, pred, weight=weight)
 
         self.last_true_label = y_true
         self.last_prediction = y_pred
@@ -624,7 +624,7 @@ class MultiTargetClassificationMeasurements(BaseObject):
         self.n_targets = m
         equal = True
         for i in range(m):
-            self.confusion_matrix.update(i, y_true[i], y_pred[i])
+            self.confusion_matrix.update(i, y_true[i], y_pred[i], weight=weight)
             # update exact_match count
             if y_true[i] != y_pred[i]:
                 equal = False
@@ -641,7 +641,7 @@ class MultiTargetClassificationMeasurements(BaseObject):
         elif np.sum(y_true) == 0:
             self.j_sum += 1
 
-        self.sample_count += 1
+        self.sample_count += weight
 
     def get_last(self):
         return self.last_true_label, self.last_prediction
@@ -815,7 +815,7 @@ class WindowMultiTargetClassificationMeasurements(BaseObject):
         self.n_targets = m
 
         for i in range(m):
-            self.confusion_matrix.update(i, y_true[i], y_pred[i])
+            self.confusion_matrix.update(i, y_true[i], y_pred[i],weight=weight)
 
         old_true = self.true_labels.add_element(y_true)
         old_predict = self.predictions.add_element(y_pred)
@@ -948,7 +948,7 @@ class RegressionMeasurements(BaseObject):
 
         self.total_square_error += (y_true - y_pred) * (y_true - y_pred)
         self.average_error += np.absolute(y_true - y_pred)
-        self.sample_count += 1
+        self.sample_count += weight
 
     def get_mean_square_error(self):
         """ Computes the mean square error.
@@ -1020,7 +1020,7 @@ class WindowRegressionMeasurements(BaseObject):
         self.total_square_error_correction = FastBuffer(self.window_size)
         self.average_error_correction = FastBuffer(self.window_size)
 
-    def add_result(self, y_true, y_pred, weight=1.0):
+    def add_result(self, y_true, y_pred):
         """ Use the true value and the prediction to update the statistics.
 
         Parameters
@@ -1031,11 +1031,8 @@ class WindowRegressionMeasurements(BaseObject):
         y_pred: float
             The predicted value.
 
-        weight: float
-            Sample's weight
-
         """
-        check_weights(weight)
+
         self.last_true_label = y_true
         self.last_prediction = y_pred
         self.total_square_error += (y_true - y_pred) * (y_true - y_pred)
@@ -1152,7 +1149,7 @@ class MultiTargetRegressionMeasurements(BaseObject):
 
         self.total_square_error += (y - prediction) ** 2
         self.average_error += np.absolute(y - prediction)
-        self.sample_count += 1
+        self.sample_count += weight
 
     def get_average_mean_square_error(self):
         """ Computes the average mean square error.
@@ -1244,7 +1241,7 @@ class WindowMultiTargetRegressionMeasurements(BaseObject):
         self.total_square_error_correction = FastBuffer(self.window_size)
         self.average_error_correction = FastBuffer(self.window_size)
 
-    def add_result(self, y, prediction, weight=1.0):
+    def add_result(self, y, prediction):
         """ Use the true value and the prediction to update the statistics.
 
         Parameters
@@ -1258,11 +1255,8 @@ class WindowMultiTargetRegressionMeasurements(BaseObject):
         prediction: float or list or np.ndarray
             The predicted value(s).
 
-        weight: float
-            Sample's weight
-
         """
-        check_weights(weight)
+
         self.last_true_label = y
         self.last_prediction = prediction
 

--- a/src/skmultiflow/metrics/measure_collection.py
+++ b/src/skmultiflow/metrics/measure_collection.py
@@ -80,7 +80,7 @@ class ClassificationMeasurements(BaseObject):
         true_y = self._get_target_index(y_true, True)
         pred = self._get_target_index(y_pred, True)
         self.confusion_matrix.update(true_y, pred)
-        self.sample_count += weight
+        self.sample_count += 1
 
         if self.get_majority_class() == y_true:
             self.majority_classifier += weight

--- a/src/skmultiflow/metrics/measure_collection.py
+++ b/src/skmultiflow/metrics/measure_collection.py
@@ -1149,7 +1149,7 @@ class MultiTargetRegressionMeasurements(BaseObject):
 
         self.total_square_error += (y - prediction) ** 2
         self.average_error += np.absolute(y - prediction)
-        self.sample_count += weight
+        self.sample_count += 1
 
     def get_average_mean_square_error(self):
         """ Computes the average mean square error.

--- a/src/skmultiflow/metrics/measure_collection.py
+++ b/src/skmultiflow/metrics/measure_collection.py
@@ -948,7 +948,7 @@ class RegressionMeasurements(BaseObject):
 
         self.total_square_error += (y_true - y_pred) * (y_true - y_pred)
         self.average_error += np.absolute(y_true - y_pred)
-        self.sample_count += weight
+        self.sample_count += 1
 
     def get_mean_square_error(self):
         """ Computes the mean square error.

--- a/src/skmultiflow/metrics/measure_collection.py
+++ b/src/skmultiflow/metrics/measure_collection.py
@@ -595,7 +595,7 @@ class MultiTargetClassificationMeasurements(BaseObject):
         self.exact_match_count = 0
         self.j_sum = 0
 
-    def add_result(self, y_true, y_pred, weight=1.0):
+    def add_result(self, y_true, y_pred):
         """ Updates its statistics with the results of a prediction.
 
         Adds the result to the MOLConfusionMatrix and update exact_matches and
@@ -609,11 +609,8 @@ class MultiTargetClassificationMeasurements(BaseObject):
         y_pred: list or numpy.ndarray
             The classifier's prediction
 
-        weight: float
-            Sample's weight
-
         """
-        check_weights(weight)
+
         self.last_true_label = y_true
         self.last_prediction = y_pred
         m = 0
@@ -624,7 +621,7 @@ class MultiTargetClassificationMeasurements(BaseObject):
         self.n_targets = m
         equal = True
         for i in range(m):
-            self.confusion_matrix.update(i, y_true[i], y_pred[i], weight=weight)
+            self.confusion_matrix.update(i, y_true[i], y_pred[i])
             # update exact_match count
             if y_true[i] != y_pred[i]:
                 equal = False
@@ -786,7 +783,7 @@ class WindowMultiTargetClassificationMeasurements(BaseObject):
         self.true_labels = FastComplexBuffer(self.window_size, self.n_targets)
         self.predictions = FastComplexBuffer(self.window_size, self.n_targets)
 
-    def add_result(self, y_true, y_pred, weight=1.0):
+    def add_result(self, y_true, y_pred):
         """ Updates its statistics with the results of a prediction.
 
         Adds the result to the MOLConfusionMatrix, and updates the
@@ -800,11 +797,8 @@ class WindowMultiTargetClassificationMeasurements(BaseObject):
         y_pred: list or numpy.ndarray
             The classifier's prediction
 
-        weight: float
-            Sample's weight
-
         """
-        check_weights(weight)
+
         self.last_true_label = y_true
         self.last_prediction = y_pred
         m = 0
@@ -815,7 +809,7 @@ class WindowMultiTargetClassificationMeasurements(BaseObject):
         self.n_targets = m
 
         for i in range(m):
-            self.confusion_matrix.update(i, y_true[i], y_pred[i],weight=weight)
+            self.confusion_matrix.update(i, y_true[i], y_pred[i])
 
         old_true = self.true_labels.add_element(y_true)
         old_predict = self.predictions.add_element(y_pred)
@@ -927,7 +921,7 @@ class RegressionMeasurements(BaseObject):
         self.last_true_label = None
         self.last_prediction = None
 
-    def add_result(self, y_true, y_pred, weight=1.0):
+    def add_result(self, y_true, y_pred):
         """ Use the true value and the prediction to update the statistics.
 
         Parameters
@@ -938,11 +932,7 @@ class RegressionMeasurements(BaseObject):
         y_pred: float
             The predicted value.
 
-        weight: float
-            Sample's weight
-
         """
-        check_weights(weight)
         self.last_true_label = y_true
         self.last_prediction = y_pred
 
@@ -1118,7 +1108,7 @@ class MultiTargetRegressionMeasurements(BaseObject):
         self.last_true_label = None
         self.last_prediction = None
 
-    def add_result(self, y, prediction, weight=1.0):
+    def add_result(self, y, prediction):
         """ Use the true value and the prediction to update the statistics.
 
         Parameters
@@ -1132,11 +1122,8 @@ class MultiTargetRegressionMeasurements(BaseObject):
         prediction: float or list or np.ndarray
             The predicted value(s).
 
-        weight: float
-            Sample's weight
-
         """
-        check_weights(weight)
+
         self.last_true_label = y
         self.last_prediction = prediction
 

--- a/src/skmultiflow/metrics/measure_collection.py
+++ b/src/skmultiflow/metrics/measure_collection.py
@@ -327,7 +327,7 @@ class WindowClassificationMeasurements(BaseObject):
         self.majority_classifier_correction = FastBuffer(self.window_size)
         self.correct_no_change_correction = FastBuffer(self.window_size)
 
-    def add_result(self, y_true, y_pred):
+    def add_result(self, y_true, y_pred, weight=1.0):
         """ Updates its statistics with the results of a prediction.
         If needed it will remove samples from the observation window.
 
@@ -339,7 +339,10 @@ class WindowClassificationMeasurements(BaseObject):
         y_pred: int
             The classifier's prediction
 
+        weight: float
+            Sample's weight
         """
+        check_weights(weight)
         true_y = self._get_target_index(y_true, True)
         pred = self._get_target_index(y_pred, True)
         old_true = self.true_labels.add_element(np.array([y_true]))
@@ -592,7 +595,7 @@ class MultiTargetClassificationMeasurements(BaseObject):
         self.exact_match_count = 0
         self.j_sum = 0
 
-    def add_result(self, y_true, y_pred):
+    def add_result(self, y_true, y_pred, weight=1.0):
         """ Updates its statistics with the results of a prediction.
 
         Adds the result to the MOLConfusionMatrix and update exact_matches and
@@ -606,7 +609,11 @@ class MultiTargetClassificationMeasurements(BaseObject):
         y_pred: list or numpy.ndarray
             The classifier's prediction
 
+        weight: float
+            Sample's weight
+
         """
+        check_weights(weight)
         self.last_true_label = y_true
         self.last_prediction = y_pred
         m = 0
@@ -779,7 +786,7 @@ class WindowMultiTargetClassificationMeasurements(BaseObject):
         self.true_labels = FastComplexBuffer(self.window_size, self.n_targets)
         self.predictions = FastComplexBuffer(self.window_size, self.n_targets)
 
-    def add_result(self, y_true, y_pred):
+    def add_result(self, y_true, y_pred, weight=1.0):
         """ Updates its statistics with the results of a prediction.
 
         Adds the result to the MOLConfusionMatrix, and updates the
@@ -793,7 +800,11 @@ class WindowMultiTargetClassificationMeasurements(BaseObject):
         y_pred: list or numpy.ndarray
             The classifier's prediction
 
+        weight: float
+            Sample's weight
+
         """
+        check_weights(weight)
         self.last_true_label = y_true
         self.last_prediction = y_pred
         m = 0
@@ -916,7 +927,7 @@ class RegressionMeasurements(BaseObject):
         self.last_true_label = None
         self.last_prediction = None
 
-    def add_result(self, y_true, y_pred):
+    def add_result(self, y_true, y_pred, weight=1.0):
         """ Use the true value and the prediction to update the statistics.
 
         Parameters
@@ -927,7 +938,11 @@ class RegressionMeasurements(BaseObject):
         y_pred: float
             The predicted value.
 
+        weight: float
+            Sample's weight
+
         """
+        check_weights(weight)
         self.last_true_label = y_true
         self.last_prediction = y_pred
 
@@ -1005,7 +1020,7 @@ class WindowRegressionMeasurements(BaseObject):
         self.total_square_error_correction = FastBuffer(self.window_size)
         self.average_error_correction = FastBuffer(self.window_size)
 
-    def add_result(self, y_true, y_pred):
+    def add_result(self, y_true, y_pred, weight=1.0):
         """ Use the true value and the prediction to update the statistics.
 
         Parameters
@@ -1016,7 +1031,11 @@ class WindowRegressionMeasurements(BaseObject):
         y_pred: float
             The predicted value.
 
+        weight: float
+            Sample's weight
+
         """
+        check_weights(weight)
         self.last_true_label = y_true
         self.last_prediction = y_pred
         self.total_square_error += (y_true - y_pred) * (y_true - y_pred)
@@ -1102,7 +1121,7 @@ class MultiTargetRegressionMeasurements(BaseObject):
         self.last_true_label = None
         self.last_prediction = None
 
-    def add_result(self, y, prediction):
+    def add_result(self, y, prediction, weight=1.0):
         """ Use the true value and the prediction to update the statistics.
 
         Parameters
@@ -1115,7 +1134,12 @@ class MultiTargetRegressionMeasurements(BaseObject):
 
         prediction: float or list or np.ndarray
             The predicted value(s).
+
+        weight: float
+            Sample's weight
+
         """
+        check_weights(weight)
         self.last_true_label = y
         self.last_prediction = prediction
 
@@ -1220,7 +1244,7 @@ class WindowMultiTargetRegressionMeasurements(BaseObject):
         self.total_square_error_correction = FastBuffer(self.window_size)
         self.average_error_correction = FastBuffer(self.window_size)
 
-    def add_result(self, y, prediction):
+    def add_result(self, y, prediction, weight=1.0):
         """ Use the true value and the prediction to update the statistics.
 
         Parameters
@@ -1233,7 +1257,12 @@ class WindowMultiTargetRegressionMeasurements(BaseObject):
 
         prediction: float or list or np.ndarray
             The predicted value(s).
+
+        weight: float
+            Sample's weight
+
         """
+        check_weights(weight)
         self.last_true_label = y
         self.last_prediction = prediction
 

--- a/src/skmultiflow/metrics/measure_collection.py
+++ b/src/skmultiflow/metrics/measure_collection.py
@@ -641,7 +641,7 @@ class MultiTargetClassificationMeasurements(BaseObject):
         elif np.sum(y_true) == 0:
             self.j_sum += 1
 
-        self.sample_count += weight
+        self.sample_count += 1
 
     def get_last(self):
         return self.last_true_label, self.last_prediction

--- a/src/skmultiflow/utils/data_structures.py
+++ b/src/skmultiflow/utils/data_structures.py
@@ -392,12 +392,12 @@ class ConfusionMatrix(BaseObject):
         self.sample_count = 0
         pass
 
-    def _update(self, i, j):
-        self.confusion_matrix[i, j] += 1
+    def _update(self, i, j, weight=1.0):
+        self.confusion_matrix[i, j] += weight
         self.sample_count += 1
         return True
 
-    def update(self, i=None, j=None):
+    def update(self, i=None, j=None, weight=1.0):
         """ update
 
         Increases by one the count of occurrences in one of the ConfusionMatrix's
@@ -410,6 +410,9 @@ class ConfusionMatrix(BaseObject):
 
         j: int
             The index of the column to be updated.
+
+        weight: float
+            Sample's weight
 
         Returns
         -------
@@ -428,7 +431,7 @@ class ConfusionMatrix(BaseObject):
         else:
             m, n = self.confusion_matrix.shape
             if (i <= m) and (i >= 0) and (j <= n) and (j >= 0):
-                return self._update(i, j)
+                return self._update(i, j, weight)
 
             else:
                 max_value = np.max(i, j)
@@ -437,7 +440,7 @@ class ConfusionMatrix(BaseObject):
 
                 else:
                     self.reshape(max_value, max_value)
-                    return self._update(i, j)
+                    return self._update(i, j, weight)
 
     def remove(self, i=None, j=None):
         """ remove
@@ -644,11 +647,11 @@ class MOLConfusionMatrix(BaseObject):
         self.confusion_matrix = np.zeros((self.n_targets, 2, 2), dtype=self.dtype)
         pass
 
-    def _update(self, target, true, pred):
-        self.confusion_matrix[int(target), int(true), int(pred)] += 1
+    def _update(self, target, true, pred, weight=1.0):
+        self.confusion_matrix[int(target), int(true), int(pred)] += weight
         return True
 
-    def update(self, target=None, true=None, pred=None):
+    def update(self, target=None, true=None, pred=None, weight=1.0):
         """ update
 
         Increases by one the occurrence count in one of the matrix's positions.
@@ -665,8 +668,12 @@ class MOLConfusionMatrix(BaseObject):
         true: int
             A true label's index.
 
+        weight: float
+            Sample's weight
+
         pred: int
             A prediction's index
+
 
         Returns
         -------
@@ -679,7 +686,7 @@ class MOLConfusionMatrix(BaseObject):
         else:
             m, n, p = self.confusion_matrix.shape
             if (target < m) and (target >= 0) and (true < n) and (true >= 0) and (pred < p) and (pred >= 0):
-                return self._update(target, true, pred)
+                return self._update(target, true, pred, weight)
             else:
                 if (true > 1) or (true < 0) or (pred > 1) or (pred < 0):
                     return False
@@ -687,7 +694,7 @@ class MOLConfusionMatrix(BaseObject):
                     return False
                 else:
                     self.reshape(target+1, 2, 2)
-                    return self._update(target, true, pred)
+                    return self._update(target, true, pred, weight)
 
     def remove(self, target=None, true=None, pred=None):
         """ remove

--- a/tests/metrics/test_measure_collection.py
+++ b/tests/metrics/test_measure_collection.py
@@ -115,7 +115,7 @@ def test_multi_target_classification_measurements():
     expected_total_sum = 300
     assert expected_total_sum == measurements.get_total_sum()
 
-    expected_info = 'MultiTargetClassificationMeasurements: - sample_count: 100 - hamming_loss: 0.066667 - ' \
+    expected_info = 'MultiTargetClassificationMeasurements: - sample_count: 100.0 - hamming_loss: 0.066667 - ' \
                     'hamming_score: 0.933333 - exact_match: 0.850000 - j_index: 0.933333'
     assert expected_info == measurements.get_info()
 
@@ -185,7 +185,7 @@ def test_regression_measurements():
     expected_ae = 0.049999999999999906
     assert np.isclose(expected_ae, measurements.get_average_error())
 
-    expected_info = 'RegressionMeasurements: - sample_count: 100 - mean_square_error: 0.002500 ' \
+    expected_info = 'RegressionMeasurements: - sample_count: 100.0 - mean_square_error: 0.002500 ' \
                     '- mean_absolute_error: 0.050000'
     assert expected_info == measurements.get_info()
 
@@ -248,7 +248,7 @@ def test_multi_target_regression_measurements():
     assert np.isclose(expected_armse,
                       measurements.get_average_root_mean_square_error())
 
-    expected_info = 'MultiTargetRegressionMeasurements: sample_count: 100 - ' \
+    expected_info = 'MultiTargetRegressionMeasurements: sample_count: 100.0 - ' \
                     'average_mean_square_error: {} - ' \
                     'average_mean_absolute_error: {} - ' \
                     'average_root_mean_square_error: {}'.format(

--- a/tests/metrics/test_measure_collection.py
+++ b/tests/metrics/test_measure_collection.py
@@ -34,7 +34,7 @@ def test_classification_measurements():
     expected_kappa_t = (expected_acc - .97) / (1 - 0.97)
     assert expected_kappa_t == measurements.get_kappa_t()
 
-    expected_info = 'ClassificationMeasurements: - sample_count: 100.0 - accuracy: 0.900000 - kappa: 0.444444 ' \
+    expected_info = 'ClassificationMeasurements: - sample_count: 100 - accuracy: 0.900000 - kappa: 0.444444 ' \
                     '- kappa_t: -2.333333 - kappa_m: 0.888889 - majority_class: 0'
     assert expected_info == measurements.get_info()
 
@@ -115,7 +115,7 @@ def test_multi_target_classification_measurements():
     expected_total_sum = 300
     assert expected_total_sum == measurements.get_total_sum()
 
-    expected_info = 'MultiTargetClassificationMeasurements: - sample_count: 100.0 - hamming_loss: 0.066667 - ' \
+    expected_info = 'MultiTargetClassificationMeasurements: - sample_count: 100 - hamming_loss: 0.066667 - ' \
                     'hamming_score: 0.933333 - exact_match: 0.850000 - j_index: 0.933333'
     assert expected_info == measurements.get_info()
 
@@ -185,7 +185,7 @@ def test_regression_measurements():
     expected_ae = 0.049999999999999906
     assert np.isclose(expected_ae, measurements.get_average_error())
 
-    expected_info = 'RegressionMeasurements: - sample_count: 100.0 - mean_square_error: 0.002500 ' \
+    expected_info = 'RegressionMeasurements: - sample_count: 100 - mean_square_error: 0.002500 ' \
                     '- mean_absolute_error: 0.050000'
     assert expected_info == measurements.get_info()
 
@@ -248,7 +248,7 @@ def test_multi_target_regression_measurements():
     assert np.isclose(expected_armse,
                       measurements.get_average_root_mean_square_error())
 
-    expected_info = 'MultiTargetRegressionMeasurements: sample_count: 100.0 - ' \
+    expected_info = 'MultiTargetRegressionMeasurements: sample_count: 100 - ' \
                     'average_mean_square_error: {} - ' \
                     'average_mean_absolute_error: {} - ' \
                     'average_root_mean_square_error: {}'.format(


### PR DESCRIPTION
Fixes #10 .

Changes proposed in this pull request:
- add parameter `weitht=1.0` in all methods `add_result` in `measure_collection.py`
- add a call method `check_weights(weight)`
- add documentation

@scikit-multiflow/scikit-multiflow-repo-admins

Checklist

- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] Tests are included for new functionality.
- [x] Travis CI build passes.
- [x] Test Coverage is maintained (threshold 0.2%)