### PR TITLE
Add documentation for scikit-multiflow Docker 

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -48,7 +48,17 @@ Option 3. Install with Docker
 =============================
 `scikit-multiflow` is also available in Docker. Docker images are located in the `skmultiflow/scikit-multiflow <https://hub.docker.com/r/skmultiflow/scikit-multiflow>`_ Docker Hub repository.
 
-You can download the image and start using `scikit-multiflow`.
+You can download the image and start using `scikit-multiflow`. Image releases are tagged using the following format:
+
+=============  ==================================================================
+tag            Description
+=============  ==================================================================
+latest         scikit-multiflow image
+jupyter        scikit-multiflow image with Jupyter
+devel          scikit-multiflow image that tracks Github repository
+devel-jupyter  scikit-multiflow image with Jupyter that tracks Github repository
+=============  ==================================================================
+
 
 Download `scikit-multiflow` Docker image
 
@@ -69,7 +79,9 @@ Run the Hoeffding Tree example
     $ python hoeffding_tree.py
 
 
-Also, we provide images with `Jupyter Notebook <http://jupyter.org/>`_. For more details, see `skmultiflow/scikit-multiflow <https://hub.docker.com/r/skmultiflow/scikit-multiflow>`_ Docker Hub repository.
+Also, for more examples see `Quick-Start Guide with Docker <user-guide.quick-start-docker.html>`_
+
+
 
 Option 4. Development version
 ====================================
@@ -111,4 +123,3 @@ In order to display plots from ``scikit-multiflow`` within a `Jupyter Notebook <
 .. code-block:: python
 
    %matplotlib ipympl
-

--- a/docs/user-guide.quick-start-docker.rst
+++ b/docs/user-guide.quick-start-docker.rst
@@ -1,0 +1,65 @@
+=============================
+Quick-Start Guide with Docker
+=============================
+
+Run Hello World example
+=======================
+
+When you start scikit-multiflow container with jupyter, you will find a ``Quick Start`` jupyter notebook.
+
+For the scikit-multiflow container with python. There are two Hello World examples.
+
+In ``hoeffding_tree.py``, data is generated from ``WaveformGenerator``.
+
+In ``ht_from_file.py``, data is generated from a csv file ``elec.csv``.
+
+
+
+Start scikit-multiflow Docker container
+
+.. code-block:: bash
+
+    $ docker run -it skmultiflow/scikit-multiflow:latest
+
+Run the Hoeffding Tree example :
+
+.. code-block:: bash
+
+    $ python hoeffding_tree.py
+
+Write your code and run it in scikit-multiflow container
+========================================================
+
+It is possible to write and edit your code on your local machine and run it in the container.
+
+First, create a work directory.
+
+.. code-block:: bash
+
+    $ mkdir workdir
+
+Second, you get the path of that directory. This will be the value of ``hostDir``
+
+.. code-block:: bash
+
+    $ cd workdir && pwd
+
+In this example, let's assume that this command returns the following path : ``/tmp/workdir``
+
+Next, you mount the directory with the following command and start scikit-multiflow container
+
+.. code-block:: bash
+
+    $ docker run -it -v /tmp/workdir:/app --shm-size 2G skmultiflow/scikit-multiflow:latest
+
+Let's download some example to ``workdir`` directory. You can also write your own code.
+
+.. code-block:: bash
+
+    $ wget https://raw.githubusercontent.com/scikit-multiflow/scikit-multiflow/master/docker/examples/src/hoeffding_tree.py
+
+Now, your files are synchronized with the container. just run it.
+
+.. code-block:: bash
+
+    $ python hoeffding_tree.py

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -9,4 +9,5 @@ In this section we cover the core concepts in *scikit-multiflow* and show how to
 
    Core Concepts <user-guide.core-concepts>
    Quick-Start Guide <user-guide.quick-start>
+   Quick-Start Guide with Docker <user-guide.quick-start-docker>
    Using Streams in scikit-multiflow <user-guide.streams-intro>


### PR DESCRIPTION
Changes proposed in this pull request:
- Add documentation for scikit-multiflow Docker 
- Some examples of how to use scikit-multiflow container.

After linking scikit-multiflow Docker Hub repository to Github, the main page of Docker Hub repository will be the same as the Github repository.
