### PR TITLE
Change default window size in KNN + ADWIN classifier

### DIFF
--- a/src/skmultiflow/lazy/knn.py
+++ b/src/skmultiflow/lazy/knn.py
@@ -26,13 +26,13 @@ class KNN(BaseSKMObject, ClassifierMixin):
     
     Parameters
     ----------
-    n_neighbors: int
+    n_neighbors: int (default=5)
         The number of nearest neighbors to search for.
         
-    max_window_size: int
+    max_window_size: int (default=1000)
         The maximum size of the window storing the last viewed samples.
         
-    leaf_size: int
+    leaf_size: int (default=30)
         The maximum number of samples that can be stored in one leaf node, 
         which determines from which point the algorithm will switch for a 
         brute-force approach. The bigger this number the faster the tree 

--- a/src/skmultiflow/lazy/knn_adwin.py
+++ b/src/skmultiflow/lazy/knn_adwin.py
@@ -78,7 +78,7 @@ class KNNAdwin(KNN):
 
     """
 
-    def __init__(self, n_neighbors=5, max_window_size=5000, leaf_size=30, nominal_attributes=None):
+    def __init__(self, n_neighbors=5, max_window_size=1000, leaf_size=30, nominal_attributes=None):
         super().__init__(n_neighbors=n_neighbors,
                          max_window_size=max_window_size,
                          leaf_size=leaf_size,

--- a/src/skmultiflow/lazy/knn_adwin.py
+++ b/src/skmultiflow/lazy/knn_adwin.py
@@ -1,4 +1,3 @@
-import sys
 from skmultiflow.lazy import KNN
 from skmultiflow.drift_detection import ADWIN
 from skmultiflow.utils.data_structures import InstanceWindow
@@ -79,7 +78,7 @@ class KNNAdwin(KNN):
 
     """
 
-    def __init__(self, n_neighbors=5, max_window_size=sys.maxsize, leaf_size=30, nominal_attributes=None):
+    def __init__(self, n_neighbors=5, max_window_size=5000, leaf_size=30, nominal_attributes=None):
         super().__init__(n_neighbors=n_neighbors,
                          max_window_size=max_window_size,
                          leaf_size=leaf_size,

--- a/src/skmultiflow/lazy/knn_adwin.py
+++ b/src/skmultiflow/lazy/knn_adwin.py
@@ -22,13 +22,13 @@ class KNNAdwin(KNN):
     
     Parameters
     ----------
-    n_neighbors: int
+    n_neighbors: int (default=5)
         The number of nearest neighbors to search for.
         
-    max_window_size: int
+    max_window_size: int (default=1000)
         The maximum size of the window storing the last viewed samples.
         
-    leaf_size: int
+    leaf_size: int (default=30)
         The maximum number of samples that can be stored in one leaf node, 
         which determines from which point the algorithm will switch for a 
         brute-force approach. The bigger this number the faster the tree 


### PR DESCRIPTION
- sys.maxsize seems to be inappropriate
- use windowsize as in https://github.com/scikit-multiflow/scikit-multiflow/blob/19a08d268d744433a52b4812a655035e402c46f2/src/skmultiflow/lazy/knn.py#L95
- e. g. sys.maxsize ends up in a window size of 9223372036854775807 on my system and also in the documentation https://scikit-multiflow.github.io/scikit-multiflow/skmultiflow.lazy.knn_adwin.html?highlight=knn%20adwin#module-skmultiflow.lazy.knn_adwin

<!-- 
Thank you for contributing with a PR!

Please fill the description of change(s) and/or if it fixes an open issue (optional).

To ease the merge process please review the attached checklist.
-->

Changes proposed in this pull request:

* 
* 
* Fixes # . [Optional]

---

Checklist

- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [ ] Tests are included for new functionality or updated accordingly.
- [x] Travis CI build passes with no errors.
- [x] Test Coverage is maintained (threshold is -0.2%).
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).
