### PR TITLE
Duplicated lines in prequential documentation example

### DIFF
--- a/src/skmultiflow/evaluation/evaluate_prequential.py
+++ b/src/skmultiflow/evaluation/evaluate_prequential.py
@@ -117,8 +117,6 @@ class EvaluatePrequential(StreamEvaluator):
     >>>                                 show_plot=True,
     >>>                                 metrics=['accuracy', 'kappa'])
     >>>
-    >>> evaluator.evaluate(stream=stream, model=ht, model_names=['HT'])
-    >>>
     >>> # Run evaluation
     >>> evaluator.evaluate(stream=stream, model=ht, model_names=['HT'])
 
@@ -163,7 +161,7 @@ class EvaluatePrequential(StreamEvaluator):
     >>>                                 show_plot=True,
     >>>                                 metrics=['accuracy'],
     >>>                                 data_points_for_classification=True)
-    >>> evaluator.evaluate(stream=stream, model=ht, model_names=['HT'])
+    >>>
     >>> # Run evaluation
     >>> evaluator.evaluate(stream=stream, model=ht, model_names=['HT'])
 


### PR DESCRIPTION
<!-- 
Thank you for contributing with a PR!

Please fill the description of change(s) and/or if it fixes an open issue (optional).

To ease the merge process please review the attached checklist.
-->
Hi, I realized there are two duplicated calls to `evaluate` in two parts of the documentation of the Prequential Evaluator. This PR simply removes them.

Changes proposed in this pull request:

*  Removed duplicated lines in the Prequential evaluator

---

I think the checklist doesn't apply to this pull request, since there is no new code proposed.