### PR TITLE
Fix bug in precision, recall, F1 and geometric mean scores

### DIFF
--- a/docs/changelog/v0.4.rst
+++ b/docs/changelog/v0.4.rst
@@ -8,6 +8,6 @@ Version 0.4.0
 
 - |Feature| Robust Soft Learning Vector Quantization classifier :class:`prototype.RobustSoftLearningVectorQuantization`
 - |Feature| Stacked Single-Target Hoeffding Tree regressor :class:`trees.StackedSingleTargetHoeffdingTreeRegressor`
-- |Feature| Half-Space Tress one-class classifier for anomaly detection :class:`anomaly_detection.HalfSpaceTrees`
+- |Feature| Half-Space Trees one-class classifier for anomaly detection :class:`anomaly_detection.HalfSpaceTrees`
 - |FIX| Fix bug in :class:`data.HyperplaneGenerator` which resulted in corrupted data when using `batch_size > 1`.
 - |Enhancement| Documentation improvements.

--- a/src/skmultiflow/_version.py
+++ b/src/skmultiflow/_version.py
@@ -21,4 +21,4 @@
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
 
-__version__ = '0.5.dev0'
+__version__ = '0.4.1'

--- a/src/skmultiflow/_version.py
+++ b/src/skmultiflow/_version.py
@@ -21,4 +21,4 @@
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
 
-__version__ = '0.4.0'
+__version__ = '0.5.dev0'

--- a/src/skmultiflow/evaluation/evaluate_holdout.py
+++ b/src/skmultiflow/evaluation/evaluate_holdout.py
@@ -48,30 +48,31 @@ class EvaluateHoldout(StreamEvaluator):
     metrics: list, optional (Default: ['accuracy', 'kappa'])
         | The list of metrics to track during the evaluation. Also defines the metrics that will be displayed in plots
           and/or logged into the output file. Valid options are
-        | *Classification*
+        | **Classification**
         | 'accuracy'
         | 'kappa'
         | 'kappa_t'
         | 'kappa_m'
         | 'true_vs_predicted'
-        | 'precision'
-        | 'recall'
-        | 'f1'
-        | 'gmean'
-        | *Multi-target Classification*
+        | 'precision'*
+        | 'recall'*
+        | 'f1'*
+        | 'gmean'*
+        | * binary-classification *only*
+        | **Multi-target Classification**
         | 'hamming_score'
         | 'hamming_loss'
         | 'exact_match'
         | 'j_index'
-        | *Regression*
+        | **Regression**
         | 'mean_square_error'
         | 'mean_absolute_error'
         | 'true_vs_predicted'
-        | *Multi-target Regression*
+        | **Multi-target Regression**
         | 'average_mean_squared_error'
         | 'average_mean_absolute_error'
         | 'average_root_mean_square_error'
-        | *Experimental*
+        | **Experimental**
         | 'running_time'
         | 'model_size'
 

--- a/src/skmultiflow/evaluation/evaluate_prequential.py
+++ b/src/skmultiflow/evaluation/evaluate_prequential.py
@@ -46,30 +46,31 @@ class EvaluatePrequential(StreamEvaluator):
     metrics: list, optional (Default: ['accuracy', 'kappa'])
         | The list of metrics to track during the evaluation. Also defines the metrics that will be displayed in plots
           and/or logged into the output file. Valid options are
-        | *Classification*
+        | **Classification**
         | 'accuracy'
         | 'kappa'
         | 'kappa_t'
         | 'kappa_m'
         | 'true_vs_predicted'
-        | 'precision'
-        | 'recall'
-        | 'f1'
-        | 'gmean'
-        | *Multi-target Classification*
+        | 'precision'*
+        | 'recall'*
+        | 'f1'*
+        | 'gmean'*
+        | * binary-classification *only*
+        | **Multi-target Classification**
         | 'hamming_score'
         | 'hamming_loss'
         | 'exact_match'
         | 'j_index'
-        | *Regression*
+        | **Regression**
         | 'mean_square_error'
         | 'mean_absolute_error'
         | 'true_vs_predicted'
-        | *Multi-target Regression*
+        | **Multi-target Regression**
         | 'average_mean_squared_error'
         | 'average_mean_absolute_error'
         | 'average_root_mean_square_error'
-        | *Experimental*
+        | **Experimental**
         | 'running_time'
         | 'model_size'
 

--- a/src/skmultiflow/metrics/measure_collection.py
+++ b/src/skmultiflow/metrics/measure_collection.py
@@ -239,7 +239,7 @@ class ClassificationMeasurements(object):
         return (p0 - pc) / (1.0 - pc)
 
     def get_g_mean(self):
-        """ Compute the G-mean of the classifier.
+        """ Compute the G-mean of the classifier. Binary-classification only.
 
         Returns
         -------
@@ -257,7 +257,7 @@ class ClassificationMeasurements(object):
         return np.sqrt((sensitivity * specificity))
 
     def get_f1_score(self):
-        """ Compute the F1-score of the classifier.
+        """ Compute the F1-score of the classifier. Binary-classification only.
 
         Returns
         -------
@@ -272,7 +272,7 @@ class ClassificationMeasurements(object):
             return 2 * ((precision * recall) / (precision + recall))
 
     def get_precision(self):
-        """ compute the precision of the classifier.
+        """ compute the precision of the classifier. Binary-classification only.
 
 
         Returns
@@ -289,7 +289,7 @@ class ClassificationMeasurements(object):
             return tp / (tp + fp)
 
     def get_recall(self):
-        """ Compute the recall.
+        """ Compute the recall of the classifier. Binary-classification only.
 
         Returns
         -------

--- a/src/skmultiflow/metrics/measure_collection.py
+++ b/src/skmultiflow/metrics/measure_collection.py
@@ -336,8 +336,8 @@ class WindowClassificationMeasurements(object):
     kept by this class are local, or partial, while the statistics kept by
     the ClassificationMeasurements class are global.
 
-    At any given moment, it can compute the following statistics: accuracy,
-    kappa, kappa_t, kappa_m, majority_class and error rate.
+    At any given moment, it can compute multiple statistics including accuracy,
+    kappa, kappa_t, kappa_m, majority_class, error rate, etc.
 
     Parameters
     ----------
@@ -593,7 +593,7 @@ class WindowClassificationMeasurements(object):
         return (p0 - pc) / (1.0 - pc)
 
     def get_g_mean(self):
-        """ Compute the G-mean of the classifier.
+        """ Compute the G-mean of the classifier. Binary-classification only.
 
         Returns
         -------
@@ -611,7 +611,7 @@ class WindowClassificationMeasurements(object):
         return np.sqrt((sensitivity * specificity))
 
     def get_f1_score(self):
-        """ Compute the F1-score of the classifier.
+        """ Compute the F1-score of the classifier. Binary-classification only.
 
         Returns
         -------
@@ -626,7 +626,7 @@ class WindowClassificationMeasurements(object):
             return 2 * ((precision * recall) / (precision + recall))
 
     def get_precision(self):
-        """ compute the precision of the classifier.
+        """ compute the precision of the classifier. Binary-classification only.
 
 
         Returns
@@ -643,7 +643,7 @@ class WindowClassificationMeasurements(object):
             return tp / (tp + fp)
 
     def get_recall(self):
-        """ Compute the recall.
+        """ Compute the recall of the classifier. Binary-classification only.
 
         Returns
         -------

--- a/src/skmultiflow/metrics/measure_collection.py
+++ b/src/skmultiflow/metrics/measure_collection.py
@@ -7,18 +7,21 @@ from timeit import default_timer as timer
 
 
 class ClassificationMeasurements(object):
-    """ Class used to keep updated statistics about a classifier, in order
+    """ Classification measurements.
+
+    Class used to keep updated statistics about a classifier, in order
     to be able to provide, at any given moment, any relevant metric about
     that classifier.
 
     It combines a ConfusionMatrix object, with some additional statistics,
-    to compute a range of performance metrics.
+    to compute a range of performance metrics. Important: indices in the
+    confusion matrix depend on the arrival order of observed classes.
 
     In order to keep statistics updated, the class won't require lots of
     information, but two: the predictions and true labels.
 
-    At any given moment, it can compute the following statistics: accuracy,
-    kappa, kappa_t, kappa_m, majority_class and error rate.
+    At any given moment, it can compute the multiple statistics including
+    accuracy, kappa, kappa_t, kappa_m, majority_class, error rate, etc.
 
     Parameters
     ----------

--- a/src/skmultiflow/utils/data_structures.py
+++ b/src/skmultiflow/utils/data_structures.py
@@ -347,7 +347,8 @@ class ConfusionMatrix(object):
     the other is associated with the predictions. If we consider the columns
     to represent predictions and the rows to represent true labels. An entry
     in position [1, 2] means that the true label was 1, while the prediction
-    was label 2, thus this was a bad prediction.
+    was label 2, thus this was a bad prediction. Important: indices in the
+    confusion matrix depend on the arrival order of observed classes.
 
     This structure is used to keep updated statistics from a classifier's
     performance, which allows to compute different evaluation metrics.

--- a/tests/evaluation/test_evaluate_holdout.py
+++ b/tests/evaluation/test_evaluate_holdout.py
@@ -68,48 +68,6 @@ def test_evaluate_holdout_classifier(tmpdir, test_path):
     assert evaluator.get_info() == expected_info
 
 
-    stream = RandomTreeGenerator(tree_random_state=23, sample_random_state=12, n_classes=2, n_cat_features=2,
-                                 n_num_features=5, n_categories_per_cat_feature=5, max_tree_depth=6, min_leaf_depth=3,
-                                 fraction_leaves_per_level=0.15)
-    stream.prepare_for_use()
-
-    # Setup learner
-    nominal_attr_idx = [x for x in range(15, len(stream.feature_names))]
-    learner = HoeffdingTree(nominal_attributes=nominal_attr_idx)
-
-    # Setup evaluator
-    n_wait = 200
-    max_samples = 1000
-    metrics = ['f1', 'precision', 'recall', 'gmean']
-    evaluator = EvaluateHoldout(n_wait=n_wait,
-                                max_samples=max_samples,
-                                test_size=50,
-                                metrics=metrics)
-
-    # Evaluate
-    evaluator.evaluate(stream=stream, model=learner)
-    mean_performance, current_performance = evaluator.get_measurements(model_idx=0)
-
-
-    expected_current_f1_score = 0.6818181818181818
-    expected_current_precision = 0.625
-    expected_current_recall = 0.75
-    expected_current_g_mean = 0.7245688373094719
-    expected_mean_f1_score = 0.6431718061674009
-    expected_mean_precision = 0.5748031496062992
-    expected_mean_recall = 0.73
-    expected_mean_g_mean = 0.6835202996254025
-
-    assert np.isclose(current_performance.get_f1_score(), expected_current_f1_score)
-    assert np.isclose(current_performance.get_precision(), expected_current_precision)
-    assert np.isclose(current_performance.get_recall(), expected_current_recall)
-    assert np.isclose(current_performance.get_g_mean(), expected_current_g_mean)
-    assert np.isclose(mean_performance.get_f1_score(), expected_mean_f1_score)
-    assert np.isclose(mean_performance.get_precision(), expected_mean_precision)
-    assert np.isclose(mean_performance.get_recall(), expected_mean_recall)
-    assert np.isclose(mean_performance.get_g_mean(), expected_mean_g_mean)
-
-
 def compare_files(test, expected):
     lines_expected = open(expected).readlines()
     lines_test = open(test).readlines()

--- a/tests/metrics/test_measure_collection.py
+++ b/tests/metrics/test_measure_collection.py
@@ -19,7 +19,7 @@ def test_classification_measurements():
     for i in range(len(y_true)):
         measurements.add_result(y_true[i], y_pred[i])
 
-    expected_acc = .9
+    expected_acc = 90/100
     assert expected_acc == measurements.get_accuracy()
 
     expected_incorrectly_classified_ratio = 1 - expected_acc
@@ -34,9 +34,21 @@ def test_classification_measurements():
     expected_kappa_t = (expected_acc - .97) / (1 - 0.97)
     assert expected_kappa_t == measurements.get_kappa_t()
 
+    expected_precision = 85 / (85+5)
+    assert np.isclose(expected_precision, measurements.get_precision())
+
+    expected_recall = 85 / (85+5)
+    assert np.isclose(expected_recall, measurements.get_recall())
+
+    expected_f1_score = 2 * ((expected_precision * expected_recall) / (expected_precision + expected_recall))
+    assert np.isclose(expected_f1_score, measurements.get_f1_score())
+
+    expected_g_mean = np.sqrt((5 / (5 + 5)) * expected_recall)
+    assert np.isclose(expected_g_mean, measurements.get_g_mean())
+
     expected_info = 'ClassificationMeasurements: - sample_count: 100 - accuracy: 0.900000 - kappa: 0.444444 ' \
-                    '- kappa_t: -2.333333 - kappa_m: 0.888889 - f1-score: 0.500000 - ' \
-                    'precision: 0.500000 - recall: 0.500000 - G-mean: 0.687184 - majority_class: 0'
+                    '- kappa_t: -2.333333 - kappa_m: 0.888889 - f1-score: 0.944444 - precision: 0.944444 ' \
+                    '- recall: 0.944444 - g-mean: 0.687184 - majority_class: 0'
     assert expected_info == measurements.get_info()
 
     expected_last = (1.0, 0.0)
@@ -50,31 +62,44 @@ def test_classification_measurements():
 
 
 def test_window_classification_measurements():
-    y_true = np.ones(100)
+    y_true = np.concatenate((np.ones(85), np.zeros(10), np.ones(5)))
     y_pred = np.concatenate((np.ones(90), np.zeros(10)))
 
     measurements = WindowClassificationMeasurements(window_size=20)
     for i in range(len(y_true)):
         measurements.add_result(y_true[i], y_pred[i])
 
-    expected_acc = .5
+    expected_acc = 10/20
     assert expected_acc == measurements.get_accuracy()
 
     expected_incorrectly_classified_ratio = 1 - expected_acc
     assert expected_incorrectly_classified_ratio == measurements.get_incorrectly_classified_ratio()
 
     expected_kappa = 0.0
-    assert expected_kappa == measurements.get_kappa()
+    assert np.isclose(expected_kappa, measurements.get_kappa())
 
-    expected_kappa_m = 0.5
-    assert expected_kappa_m == measurements.get_kappa_m()
+    expected_kappa_m = -1.0
+    assert np.isclose(expected_kappa_m, measurements.get_kappa_m())
 
-    expected_kappa_t = 1
-    assert expected_kappa_t == measurements.get_kappa_t()
+    expected_kappa_t = -4.0
+    assert np.isclose(expected_kappa_t, measurements.get_kappa_t())
 
-    expected_info = 'WindowClassificationMeasurements: - sample_count: 20 - window_size: 20 - accuracy: 0.500000 ' \
-                    '- kappa: 0.000000 - kappa_t: 1.000000 - kappa_m: 0.500000 - f1-score: 0.000000 - ' \
-                    'precision: 0.000000 - recall: 0.000000 - G-mean: 0.000000 - majority_class: 0'
+    expected_precision = 5 / (5 + 5)
+    assert np.isclose(expected_precision, measurements.get_precision())
+
+    expected_recall = 5 / (5 + 5)
+    assert np.isclose(expected_recall, measurements.get_recall())
+
+    expected_f1_score = 2 * ((expected_precision * expected_recall) / (expected_precision + expected_recall))
+    assert np.isclose(expected_f1_score, measurements.get_f1_score())
+
+    expected_g_mean = np.sqrt((5 / (5 + 5)) * expected_recall)
+    assert np.isclose(expected_g_mean, measurements.get_g_mean())
+
+    expected_info = 'WindowClassificationMeasurements: - sample_count: 20 - window_size: 20 ' \
+                    '- accuracy: 0.500000 - kappa: 0.000000 - kappa_t: -4.000000 ' \
+                    '- kappa_m: -1.000000 - f1-score: 0.500000 - precision: 0.500000 ' \
+                    '- recall: 0.500000 - g-mean: 0.500000 - majority_class: 0'
     assert expected_info == measurements.get_info()
 
     expected_last = (1.0, 0.0)


### PR DESCRIPTION
<!-- 
Thank you for contributing with a PR!

Please fill the description of change(s) and/or if it fixes an open issue (optional).

To ease the merge process please review the attached checklist.
-->

Changes proposed in this pull request:

During work to improve test coverage of the evaluators a bug was found in the calculation of precision and recall which in places affects the f1-score and geometric mean scores.

The bug is triggered by the order of the observed classes. This is because of the confusion matrix used internally which maps the observed classes by the order of arrival and not the class-value itself.

PR is composed of:
1) Fix bug in precision, recall, f1-score, and geometric mean
2) Improved tests for metrics
3) Improved test coverage for evaluators

---

Checklist

- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] Tests are included for new functionality or updated accordingly.
- [x] Travis CI build passes with no errors.
- [x] Test Coverage is maintained (threshold is -0.2%).
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).
