### PR TITLE
Fix index out of range for the classification functions in the mixed …

### DIFF
--- a/src/skmultiflow/data/mixed_generator.py
+++ b/src/skmultiflow/data/mixed_generator.py
@@ -286,10 +286,7 @@ class MIXEDGenerator(Stream):
 
     def generate_drift(self):
         """
-        Generate drift by switching the classification function randomly.
+        Generate drift by switching the classification function.
 
         """
-        new_function = self._random_state.randint(2)
-        while new_function == self.classification_function:
-            new_function = self._random_state.randint(2)
-        self.classification_function = new_function
+        self.classification_function = 1 - self.classification_function

--- a/src/skmultiflow/data/mixed_generator.py
+++ b/src/skmultiflow/data/mixed_generator.py
@@ -25,8 +25,8 @@ class MIXEDGenerator(Stream):
     Parameters
     ----------
     classification_function: int (default: 0)
-        Which of the four classification functions to use for the generation.
-        The value can vary from 0 to 1.
+        Which of the two classification functions to use for the generation.
+        Valid options are 0 or 1.
 
     random_state: int, RandomState instance or None, optional (default=None)
         If int, random_state is the seed used by the random number generator;

--- a/src/skmultiflow/data/mixed_generator.py
+++ b/src/skmultiflow/data/mixed_generator.py
@@ -107,7 +107,7 @@ class MIXEDGenerator(Stream):
         Returns
         -------
         int
-            index of the classification function [0,1,2]
+            index of the classification function [0,1]
         """
         return self._classification_function_idx
 
@@ -289,7 +289,7 @@ class MIXEDGenerator(Stream):
         Generate drift by switching the classification function randomly.
 
         """
-        new_function = self._random_state.randint(3)
+        new_function = self._random_state.randint(2)
         while new_function == self.classification_function:
-            new_function = self._random_state.randint(3)
+            new_function = self._random_state.randint(2)
         self.classification_function = new_function


### PR DESCRIPTION
The mixed generator only has 2 classification functions [0, 1].

<!-- 
Thank you for contributing with a PR!

Please fill the description of change(s) and/or if it fixes an open issue (optional).

To ease the merge process please review the attached checklist.
-->

Changes proposed in this pull request:

* Fixes the index out of range error when generating drifts by the mixed generator.

---

Checklist

- [X] Code complies with PEP-8 and is consistent with the framework.
- [X] Code is properly documented.
- [ ] Tests are included for new functionality or updated accordingly.
- [X] Travis CI build passes with no errors.
- [X] Test Coverage is maintained (threshold is -0.2%).
- [X] Files changed (update, add, delete) are in the PR's scope (no extra files are included).
