### PR TITLE
Fix in IntraClusterVarianceReduction bug

### DIFF
--- a/src/skmultiflow/trees/intra_cluster_variance_reduction_split_criterion.py
+++ b/src/skmultiflow/trees/intra_cluster_variance_reduction_split_criterion.py
@@ -17,8 +17,8 @@ class IntraClusterVarianceReductionSplitCriterion(
 
         count = 0
 
-        for i in post_split_dist:
-            Ni = i[0]
+        for dist in post_split_dist:
+            Ni = dist[0]
             if Ni >= 5.0:
                 count += 1
 
@@ -37,4 +37,4 @@ class IntraClusterVarianceReductionSplitCriterion(
         sum = dist[1]
         sum_sq = dist[2]
 
-        return np.sum((sum_sq - (sum * sum) / N) / (N - 1))
+        return np.mean((sum_sq - ((sum * sum) / N)) / (N - 1))


### PR DESCRIPTION
Fixing bug in `IntraClusterVarianceReduction` (`skmultiflow.trees`) calculation.

The current implementation of this split criterion was using `np.sum` to aggregate the `VarianceReduction` values of each target. This PR changes it to `np.mean`, as originally proposed.

Changes proposed in this pull request:

* Renaming some variables for conciseness 
* Fixing the way in which `IntraClusterVarianceReduction` is calculated.

---

Checklist

- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] Tests are included for new functionality or updated accordingly.
- [x] Travis CI build passes with no errors.
- [x] Test Coverage is maintained (threshold is -0.2%).
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).
