### PR TITLE
[BUG] Fix in subtree_depth calculation

### DIFF
--- a/src/skmultiflow/trees/nodes/split_node.py
+++ b/src/skmultiflow/trees/nodes/split_node.py
@@ -133,7 +133,7 @@ class SplitNode(Node):
             Subtree depth, 0 if node is a leaf.
         """
         max_child_depth = 0
-        for child in self._children:
+        for child in self._children.values():
             if child is not None:
                 depth = child.subtree_depth()
                 if depth > max_child_depth:

--- a/tests/trees/test_hoeffding_tree.py
+++ b/tests/trees/test_hoeffding_tree.py
@@ -136,3 +136,31 @@ def test_hoeffding_tree_coverage():
     X, y = stream.next_sample(1000)
     learner = HoeffdingTree(leaf_prediction='mc', nominal_attributes=[i for i in range(10)])
     learner.partial_fit(X, y, classes=stream.target_values)
+
+
+def test_hoeffding_tree_model_information():
+    stream = SEAGenerator(random_state=1, noise_percentage=0.05)
+    stream.prepare_for_use()
+    X, y = stream.next_sample(5000)
+
+    nominal_attr_idx = [x for x in range(5, stream.n_features)]
+    learner = HoeffdingTree(nominal_attributes=nominal_attr_idx)
+
+    learner.partial_fit(X, y, classes=stream.target_values)
+
+    expected_info = "{'Tree size (nodes)': 5, 'Tree size (leaves)': 3, " \
+                    "'Active learning nodes': 3, 'Tree depth': 2, 'Active " \
+                    "leaf byte size estimate': 0.0, 'Inactive leaf byte " \
+                    "size estimate': 0.0, 'Byte size estimate overhead': 1.0}"
+
+    assert expected_info == str(learner.get_model_measurements)
+
+    expected_description = "if Attribute 0 <= 4.549969620513424:\n" \
+                            "  if Attribute 1 <= 5.440182925299016:\n" \
+                            "    Leaf = Class 0 | {0: 345.54817975126275, 1: 44.43855503614928}\n" \
+                            "  if Attribute 1 > 5.440182925299016:\n" \
+                            "    Leaf = Class 1 | {0: 54.451820248737235, 1: 268.5614449638507}\n" \
+                            "if Attribute 0 > 4.549969620513424:\n" \
+                            "  Leaf = Class 1 | {0: 390.5845685762964, 1: 2372.3747376855454}\n" \
+
+    assert expected_description == learner.get_model_description()

--- a/tests/trees/test_hoeffding_tree.py
+++ b/tests/trees/test_hoeffding_tree.py
@@ -148,12 +148,20 @@ def test_hoeffding_tree_model_information():
 
     learner.partial_fit(X, y, classes=stream.target_values)
 
-    expected_info = "{'Tree size (nodes)': 5, 'Tree size (leaves)': 3, " \
-                    "'Active learning nodes': 3, 'Tree depth': 2, 'Active " \
-                    "leaf byte size estimate': 0.0, 'Inactive leaf byte " \
-                    "size estimate': 0.0, 'Byte size estimate overhead': 1.0}"
+    expected_info = {
+        'Tree size (nodes)': 5,
+        'Tree size (leaves)': 3,
+        'Active learning nodes': 3,
+        'Tree depth': 2,
+        'Active leaf byte size estimate': 0.0,
+        'Inactive leaf byte size estimate': 0.0,
+        'Byte size estimate overhead': 1.0
+    }
 
-    assert expected_info == str(learner.get_model_measurements)
+    observed_info = learner.get_model_measurements
+    for k in expected_info:
+        assert k in observed_info
+        assert expected_info[k] == observed_info[k]
 
     expected_description = "if Attribute 0 <= 4.549969620513424:\n" \
                             "  if Attribute 1 <= 5.440182925299016:\n" \


### PR DESCRIPTION
This PR fixes a bug in the depth calculation for Hoeffding Trees.

Changes proposed in this pull request:

* Fix the depth calculation for Hoeffding Trees: when iterating over their nodes, the HTs were accessing the key values of their internal structures rather than the actual nodes.
* The bug and proposed fix have no impact on the performance of the Hoeffding Tree. This method is mainly used for informative purposes via the `get_model_measurements` method.
---

Checklist

- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] Tests are included for new functionality or updated accordingly.
- [x] Travis CI build passes with no errors.
- [x] Test Coverage is maintained (threshold is -0.2%).
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).
