### PR TITLE
Add a generic wrapper for forecasting classes.

### DIFF
--- a/src/skmultiflow/core/__init__.py
+++ b/src/skmultiflow/core/__init__.py
@@ -5,12 +5,15 @@ The :mod:`skmultiflow.core` module covers core elements of `scikit-multiflow`.
 from .base import BaseSKMObject
 from .base import ClassifierMixin
 from .base import RegressorMixin
+from .base import ForecasterMixin
 from .base import MetaEstimatorMixin
 from .base import MultiOutputMixin
 from .base import clone
 from .base import is_classifier
 from .base import is_regressor
+from .base import is_forecaster
 from .pipeline import Pipeline
 
-__all__ = ["BaseSKMObject", "ClassifierMixin", "RegressorMixin", "MetaEstimatorMixin",
-           "MultiOutputMixin", "Pipeline", "clone", "is_classifier", "is_regressor"]
+__all__ = ["BaseSKMObject", "ClassifierMixin", "RegressorMixin",
+           "ForecasterMixin", "MetaEstimatorMixin", "MultiOutputMixin",
+           "Pipeline", "clone", "is_classifier", "is_regressor", "is_forecaster"]

--- a/tests/core/test_base.py
+++ b/tests/core/test_base.py
@@ -1,6 +1,6 @@
 from array import array
 
-from skmultiflow.core import clone
+from skmultiflow.core import clone, ForecasterMixin
 from skmultiflow.core.base import _pprint
 from skmultiflow.data import SEAGenerator
 from skmultiflow.bayes import NaiveBayes
@@ -9,6 +9,7 @@ from skmultiflow.trees import HoeffdingTreeRegressor
 from skmultiflow.trees import iSOUPTreeRegressor
 from skmultiflow.core import is_classifier
 from skmultiflow.core import is_regressor
+from skmultiflow.core import is_forecaster
 
 
 def test_clone():
@@ -129,3 +130,17 @@ def test_is_classifier():
 def test_is_regressor():
     learner = HoeffdingTreeRegressor()
     assert is_regressor(learner) is True
+
+
+def test_is_forecaster():
+    ForecasterMixin.__abstractmethods__ = set()
+    learner = ForecasterMixin()
+    assert is_forecaster(learner) is True
+
+
+def test_forecaster_default_parameters():
+    ForecasterMixin.__abstractmethods__ = set()
+    forecaster = ForecasterMixin()
+    forecaster.__init__()
+    assert forecaster.k is 1
+    assert forecaster.l is 1


### PR DESCRIPTION
[Issue](https://github.com/scikit-multiflow/scikit-multiflow/issues/133)

This is a base class where raw stream of inputs x are transformed into a data stream x, y1,y2,...,yk where k is defined as a parameter to the number of steps to forecast and the training is done such as (x=x[t-1], y=x[t+k]) at moment t. Also training of the model is trivial to the user.

Changes proposed in this pull request:

* A new base class for forecasting. 

---

Checklist

- [ ] Code complies with PEP-8 and is consistent with the framework.
- [ ] Code is properly documented.
- [ ] Tests are included for new functionality or updated accordingly.
- [ ] Travis CI build passes with no errors.
- [ ] Test Coverage is maintained (threshold is -0.2%).
- [ ] Files changed (update, add, delete) are in the PR's scope (no extra files are included).
