### PR TITLE
Remove syntax warning in trees/nodes/node.py .

### DIFF
--- a/src/skmultiflow/trees/nodes/node.py
+++ b/src/skmultiflow/trees/nodes/node.py
@@ -102,7 +102,7 @@ class Node(metaclass=ABCMeta):
         """
         count = 0
         for _, weight in self._observed_class_distribution.items():
-            if weight is not 0:
+            if weight != 0:
                 count += 1
                 if count == 2:  # No need to count beyond this point
                     break


### PR DESCRIPTION
Changes proposed in this pull request:

* Remove Syntax Warning in trees/nodes/node.py by changing 'foo is not 0' into 'foo != 0'

---

Checklist

- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] Tests are included for new functionality or updated accordingly.
- [x] Travis CI build passes with no errors.
- [x] Test Coverage is maintained (threshold is -0.2%).
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).
