### PR TITLE
Bugfix in ADWIN.

### DIFF
--- a/src/skmultiflow/drift_detection/adwin.py
+++ b/src/skmultiflow/drift_detection/adwin.py
@@ -252,7 +252,7 @@ class ADWIN(BaseDriftDetector):
                 n2 = self.bucket_size(i)
                 u1 = cursor.get_total(0)/n1
                 u2 = cursor.get_total(1)/n2
-                incremental_variance = n1 * n2 * (u1 - u2) / (n1 + n2)
+                incremental_variance = n1 * n2 * (u1 - u2)**2 / (n1 + n2)
                 next_node.insert_bucket(cursor.get_total(0) + cursor.get_total(1), cursor.get_variance(1)
                                         + incremental_variance)
                 self.bucket_number += 1

--- a/src/skmultiflow/drift_detection/adwin.py
+++ b/src/skmultiflow/drift_detection/adwin.py
@@ -252,7 +252,7 @@ class ADWIN(BaseDriftDetector):
                 n2 = self.bucket_size(i)
                 u1 = cursor.get_total(0)/n1
                 u2 = cursor.get_total(1)/n2
-                incremental_variance = n1 * n2 * (u1 - u2)**2 / (n1 + n2)
+                incremental_variance = n1 * n2 * ((u1 - u2) * (u1 - u2)) / (n1 + n2)
                 next_node.insert_bucket(cursor.get_total(0) + cursor.get_total(1), cursor.get_variance(1)
                                         + incremental_variance)
                 self.bucket_number += 1


### PR DESCRIPTION
Changes proposed in this pull request:

* Fix a bug in the computation of the `incremental_variance` in `__compress_buckets()`, where a square was missing:

#### Wrong
```python
incremental_variance = n1 * n2 * (u1 - u2) / (n1 + n2)
```

#### Correct
```python
incremental_variance = n1 * n2 * ((u1 - u2) * (u1 - u2)) / (n1 + n2)
```

* Fix does not seem to have a significant impact on methods relying on ADWIN to detect drift. 

---

Checklist

- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] Tests are included for new functionality or updated accordingly.
- [x] Travis CI build passes with no errors.
- [x] Test Coverage is maintained (threshold is -0.2%).
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).
