### PR TITLE
Optimise a ** 2 in a * a.

### DIFF
--- a/src/skmultiflow/meta/accuracy_weighted_ensemble.py
+++ b/src/skmultiflow/meta/accuracy_weighted_ensemble.py
@@ -308,7 +308,7 @@ class AccuracyWeightedEnsembleClassifier(BaseSKMObject, ClassifierMixin, MetaEst
             if c in labels:
                 index_label_c = np.where(labels == c)[0][0]  # find the index of this label c in probabs[i]
                 probab_ic = probabs[i][index_label_c]
-                sum_error += (1.0 - probab_ic) ** 2
+                sum_error += (1.0 - probab_ic) * (1.0 - probab_ic)
             else:
                 sum_error += 1.0
 
@@ -402,7 +402,9 @@ class AccuracyWeightedEnsembleClassifier(BaseSKMObject, ClassifierMixin, MetaEst
 
         # if we base on the class distribution of the data --> count the number of labels
         classes, class_count = np.unique(y, return_counts=True)
-        class_dist = [class_count[i] / len(y) for i, c in enumerate(classes)]
-        mse_r = np.sum([class_dist[i] * ((1 - class_dist[i]) ** 2) for i, c in enumerate(classes)])
+        class_dist = [class_count[i] / len(y) for i in range(len(classes))]
+        mse_r = np.sum([(class_dist[i]
+                         * (1 - class_dist[i])
+                         * (1 - class_dist[i])) for i in range(len(classes))])
 
         return mse_r

--- a/src/skmultiflow/metrics/measure_collection.py
+++ b/src/skmultiflow/metrics/measure_collection.py
@@ -1295,7 +1295,7 @@ class MultiTargetRegressionMeasurements(object):
             m = len(y)
         self.n_targets = m
 
-        self.total_square_error += (y - prediction) ** 2
+        self.total_square_error += (y - prediction) * (y - prediction)
         self.average_error += np.absolute(y - prediction)
         self.sample_count += 1
 
@@ -1413,11 +1413,11 @@ class WindowMultiTargetRegressionMeasurements(object):
             m = len(y)
         self.n_targets = m
 
-        self.total_square_error += (y - prediction) ** 2
+        self.total_square_error += (y - prediction) * (y - prediction)
         self.average_error += np.absolute(y - prediction)
 
         old_square = self.total_square_error_correction.add_element(
-            np.array([-1 * ((y - prediction) ** 2)])
+            np.array([-1 * (y - prediction) * (y - prediction)])
         )
         old_average = self.average_error_correction.add_element(
             np.array([-1 * (np.absolute(y - prediction))])

--- a/src/skmultiflow/prototype/robust_soft_learning_vector_quantization.py
+++ b/src/skmultiflow/prototype/robust_soft_learning_vector_quantization.py
@@ -123,18 +123,20 @@ class RobustSoftLearningVectorQuantization(ClassifierMixin, BaseSKMObject):
             gradient = - self._p(j, xi, prototypes=self.w_) * d
 
         # Accumulate gradient
-        self.squared_mean_gradient[j] = self.gamma * \
-            self.squared_mean_gradient[j] + (1 - self.gamma) \
-            * gradient ** 2
+        self.squared_mean_gradient[j] = (self.gamma
+                                         * self.squared_mean_gradient[j]
+                                         + (1 - self.gamma)
+                                            * gradient
+                                            * gradient)
 
         # Compute update/step
-        step = ((self.squared_mean_step[j] + self.epsilon) /
-                (self.squared_mean_gradient[j] + self.epsilon)) ** 0.5 * \
-            gradient
+        step = (np.sqrt((self.squared_mean_step[j] + self.epsilon)
+                        / (self.squared_mean_gradient[j] + self.epsilon))
+                * gradient)
 
         # Accumulate updates
-        self.squared_mean_step[j] = self.gamma * \
-            self.squared_mean_step[j] + (1 - self.gamma) * step ** 2
+        self.squared_mean_step[j] = (self.gamma * self.squared_mean_step[j]
+                                     + (1 - self.gamma) * step * step)
 
         # Attract/Distract prototype to/from data point
         self.w_[j] += step

--- a/src/skmultiflow/trees/isoup_tree.py
+++ b/src/skmultiflow/trees/isoup_tree.py
@@ -212,7 +212,8 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, MultiOutputMixin):
 
         mean = self.sum_of_attribute_values / self.examples_seen
         variance = (self.sum_of_attribute_squares -
-                    (self.sum_of_attribute_values ** 2) /
+                    (self.sum_of_attribute_values *
+                     self.sum_of_attribute_values) /
                     self.examples_seen) / (self.examples_seen - 1)
 
         sd = np.sqrt(variance, out=np.zeros_like(variance),
@@ -245,7 +246,8 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, MultiOutputMixin):
 
         mean = self.sum_of_values / self.examples_seen
         variance = (self.sum_of_squares -
-                    (self.sum_of_values ** 2) /
+                    (self.sum_of_values *
+                     self.sum_of_values) /
                     self.examples_seen) / (self.examples_seen - 1)
 
         sd = np.sqrt(variance, out=np.zeros_like(variance),
@@ -504,7 +506,8 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, MultiOutputMixin):
                                   normalized_sample)
                     mean = self.sum_of_values / self.examples_seen
                     variance = (self.sum_of_squares -
-                                (self.sum_of_values ** 2) /
+                                (self.sum_of_values *
+                                 self.sum_of_values) /
                                 self.examples_seen) / (self.examples_seen - 1)
                     sd = np.sqrt(variance, out=np.zeros_like(variance),
                                  where=variance >= 0.0)
@@ -533,7 +536,8 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, MultiOutputMixin):
                                       normalized_sample)
                         mean = self.sum_of_values / self.examples_seen
                         variance = (self.sum_of_squares -
-                                    (self.sum_of_values ** 2) /
+                                    (self.sum_of_values *
+                                     self.sum_of_values) /
                                     self.examples_seen) / (self.examples_seen - 1)
                         sd = np.sqrt(variance, out=np.zeros_like(variance),
                                      where=variance >= 0.0)

--- a/src/skmultiflow/trees/stacked_single_target_hoeffding_tree_regressor.py
+++ b/src/skmultiflow/trees/stacked_single_target_hoeffding_tree_regressor.py
@@ -240,7 +240,8 @@ class StackedSingleTargetHoeffdingTreeRegressor(iSOUPTreeRegressor, MultiOutputM
                     )
                     mean = self.sum_of_values / self.examples_seen
                     variance = (self.sum_of_squares -
-                                (self.sum_of_values ** 2) /
+                                (self.sum_of_values *
+                                 self.sum_of_values) /
                                 self.examples_seen) / (self.examples_seen - 1)
                     sd = np.sqrt(variance, out=np.zeros_like(variance),
                                  where=variance >= 0.0)
@@ -277,7 +278,8 @@ class StackedSingleTargetHoeffdingTreeRegressor(iSOUPTreeRegressor, MultiOutputM
 
                         mean = self.sum_of_values / self.examples_seen
                         variance = (self.sum_of_squares -
-                                    (self.sum_of_values ** 2) /
+                                    (self.sum_of_values *
+                                     self.sum_of_values) /
                                     self.examples_seen) / (self.examples_seen - 1)
                         sd = np.sqrt(variance, out=np.zeros_like(variance),
                                      where=variance >= 0.0)


### PR DESCRIPTION
This PR changes power operations to increase performance.

- `a * a` is about three times faster than `a ** 2`, so prefer it whenever it does not hinder readability.
- a instance of `a ** 0.5` in `RobustSoftLearningVectorQuantization` is also changed to `np.sqrt(a)`, for clarity

---

Checklist

- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] Tests are included for new functionality or updated accordingly.
- [x] Travis CI build passes with no errors.
- [x] Test Coverage is maintained (threshold is -0.2%).
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).
