### PR TITLE
[BUG] Add check for zero sum to avoid division by zero in Naive Bayes Prediction

### DIFF
--- a/src/skmultiflow/bayes/utils.py
+++ b/src/skmultiflow/bayes/utils.py
@@ -22,11 +22,11 @@ def do_naive_bayes_prediction(X, observed_class_distribution: dict, attribute_ob
     -----
     This method is not intended to be used as a stand-alone method.
     """
-    if observed_class_distribution == {}:
+    observed_class_sum = sum(observed_class_distribution.values())
+    if observed_class_distribution == {} or observed_class_sum == 0.0:
         # No observed class distributions, all classes equal
         return {0: 0.0}
     votes = {}
-    observed_class_sum = sum(observed_class_distribution.values())
     for class_index, observed_class_val in observed_class_distribution.items():
         votes[class_index] = observed_class_val / observed_class_sum
         if attribute_observers:


### PR DESCRIPTION
<!-- 
Thank you for contributing with a PR!

Please fill the description of change(s) and/or if it fixes an open issue (optional).

To ease the merge process please review the attached checklist.
-->

Changes proposed in this pull request:

* Add additional check if the sum of class distribution values is zero 
* Prevents division by zero in https://github.com/scikit-multiflow/scikit-multiflow/blob/8c69795850beb277cbd094c38e53c8ceb3cd2ae9/src/skmultiflow/bayes/utils.py#L31
* Addresses #165  . 

The bug occurred when using ARF with leaf_predicition='nba' (default setting) and the sum of class distribution values being equal to zero.

---

Checklist

- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] Tests are included for new functionality or updated accordingly.
- [x] Travis CI build passes with no errors.
- [x] Test Coverage is maintained (threshold is -0.2%).
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).
