### PR TITLE
minor: rn parameter name from weight to sample_weight

### DIFF
--- a/src/skmultiflow/meta/online_rus_boost.py
+++ b/src/skmultiflow/meta/online_rus_boost.py
@@ -129,7 +129,7 @@ class OnlineRUSBoostClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixi
     def reset(self):
         self.__configure()
 
-    def partial_fit(self, X, y, classes=None, weight=None):
+    def partial_fit(self, X, y, classes=None, sample_weight=None):
         """ Partially fits the model, based on the X and y matrix.
 
         Since it's an ensemble learner, if X and y matrix of more than one
@@ -220,7 +220,7 @@ class OnlineRUSBoostClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixi
                 k = self._random_state.poisson(lam_rus)
                 if k > 0:
                     for b in range(k):
-                        self.ensemble[i].partial_fit([X[j]], [y[j]], classes, weight)
+                        self.ensemble[i].partial_fit([X[j]], [y[j]], classes, sample_weight)
                 if self.ensemble[i].predict([X[j]])[0] == y[j]:
                     self.lam_sc[i] += lam
                     self.epsilon[i] = (self.lam_sw[i]) / (self.lam_sc[i] + self.lam_sw[i])

--- a/src/skmultiflow/rules/very_fast_decision_rules.py
+++ b/src/skmultiflow/rules/very_fast_decision_rules.py
@@ -449,7 +449,7 @@ class VeryFastDecisionRulesClassifier(BaseSKMObject, ClassifierMixin):
 
         return final_votes if fired_rule else self.default_rule.get_class_votes(X, self)
 
-    def partial_fit(self, X, y, classes=None, weight=None):
+    def partial_fit(self, X, y, classes=None, sample_weight=None):
         """Incrementally trains the model.
 
         Train samples (instances) are composed of X attributes and their corresponding targets y.
@@ -476,7 +476,7 @@ class VeryFastDecisionRulesClassifier(BaseSKMObject, ClassifierMixin):
         classes: list or numpy.array
             Contains the class values in the stream. If defined, will be used to define the length of the arrays
             returned by `predict_proba`
-        weight: float or array-like
+        sample_weight: float or array-like
             Instance weight. If not provided, uniform weights are assumed.
 
         Returns
@@ -488,13 +488,13 @@ class VeryFastDecisionRulesClassifier(BaseSKMObject, ClassifierMixin):
             self.classes = classes
         if y is not None:
             row_cnt, _ = get_dimensions(X)
-            if weight is None:
-                weight = np.ones(row_cnt)
-            if row_cnt != len(weight):
-                raise ValueError('Inconsistent number of instances ({}) and weights ({}).'.format(row_cnt, len(weight)))
+            if sample_weight is None:
+                sample_weight = np.ones(row_cnt)
+            if row_cnt != len(sample_weight):
+                raise ValueError('Inconsistent number of instances ({}) and weights ({}).'.format(row_cnt, len(sample_weight)))
             for i in range(row_cnt):
-                if weight[i] != 0.0:
-                    self._partial_fit(X[i], y[i], weight[i])
+                if sample_weight[i] != 0.0:
+                    self._partial_fit(X[i], y[i], sample_weight[i])
 
         return self
 


### PR DESCRIPTION
Refers to this issue:
**Inconsistent use of sample_weight vs weight parameters [BUG] #190**

This should be very minor: partial_fit and fit functions, if they have sample weights, this parameter should have a consistent name. I found (only) two instances where the parameter is called **weight** instead of **sample_weight** (for some reason, I thought there were more). I changed these to sample_weight (+documentation) and checked that it doesn't break anything. 

I am very impressed by this library, and all the work all of you have been putting in. Perhaps to flag: I didn't find any tests using the weights. 

- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] Tests are included for new functionality or updated accordingly.
