### PR TITLE
Fix bug in methods that failed when `predict` was called before the first partial_fit/fit

### DIFF
--- a/src/skmultiflow/lazy/knn_classifier.py
+++ b/src/skmultiflow/lazy/knn_classifier.py
@@ -18,22 +18,10 @@ def KNN(n_neighbors=5, max_window_size=1000, leaf_size=30, nominal_attributes=No
 class KNNClassifier(BaseSKMObject, ClassifierMixin):
     """ K-Nearest Neighbors classifier.
     
-    This is a non-parametric classification method. The output of this
-    algorithm are the n_neighbors closest training examples to the query sample
-    X.
-    
-    It works by keeping track of a fixed number of training samples, in 
-    our case it keeps track of the last max_window_size training samples.
-    Then, whenever a query request is executed, the algorithm will search 
-    its stored samples and find the closest ones using a selected distance 
-    metric.
-    
-    To store the samples, while reducing search times, we use a structure 
-    called KD Tree (a K Dimensional Tree, for n_neighbors dimensional problems).
-    Although we do have our own KDTree implementation, which accepts 
-    custom metrics, we recommend using the standard scikit-learn KDTree,  
-    that even though doesn't accept custom metrics, is optimized and will 
-    function faster.
+    This non-parametric classification method keeps track of the last max_window_size
+    training samples. Predictions are obtained by aggregating the values of the
+    closest n_neighbors stored-samples with respect to the query sample.
+
     
     Parameters
     ----------
@@ -52,25 +40,10 @@ class KNNClassifier(BaseSKMObject, ClassifierMixin):
     nominal_attributes: numpy.ndarray (optional, default=None)
         List of Nominal attributes. If empty, then assume that all attributes are numerical.
     
-    Raises
-    ------
-    NotImplementedError: A few of the functions described here are not 
-    implemented since they have no application in this context.
-    
-    ValueError: A ValueError is raised if the predict function is called 
-    before at least n_neighbors samples have been analyzed by the algorithm.
-    
     Notes
     -----
-    For a KDTree functionality explanation, please see our KDTree 
-    documentation, under skmultiflow.lazy.neighbors.kdtree.
-    
-    This classifier is not optimal for a mixture of categorical and 
-    numerical features.
-    
-    If you wish to use our KDTree implementation please refer to this class' 
-    function __predict_proba
-    
+    This classifier is not optimal for a mixture of categorical and numerical features.
+
     Examples
     --------
     >>> # Imports
@@ -161,10 +134,7 @@ class KNNClassifier(BaseSKMObject, ClassifierMixin):
         return self
 
     def predict(self, X):
-        """ predict
-        
-        Predicts the label of the X sample, by searching the KDTree for 
-        the n_neighbors-Nearest Neighbors.
+        """ Predicts the class label of the X sample.
         
         Parameters
         ----------
@@ -185,20 +155,11 @@ class KNNClassifier(BaseSKMObject, ClassifierMixin):
         return np.array(predictions)
 
     def predict_proba(self, X):
-        """ predict_proba
-         
-        Calculates the probability of each sample in X belonging to each 
-        of the labels, based on the knn algorithm.
+        """ Estimates the probability of each sample in X belonging to each of the class-labels.pyte
         
         Parameters
         ----------
         X: Numpy.ndarray of shape (n_samples, n_features)
-        
-        Raises
-        ------
-        ValueError: If there is an attempt to call this function before, 
-        at least, n_neighbors samples have been analyzed by the learner, a ValueError
-        is raised.
         
         Returns
         -------
@@ -209,10 +170,11 @@ class KNNClassifier(BaseSKMObject, ClassifierMixin):
             the probability that the i-th sample of X belongs to a certain label.
          
         """
-        if self.window is None or self.window.n_samples < self.n_neighbors:
-            raise ValueError("KNNClassifier must be (partially) fitted on n_neighbors samples before doing any prediction.")
-        proba = []
         r, c = get_dimensions(X)
+        if self.window is None or self.window.n_samples < self.n_neighbors:
+            # The model is empty, defaulting to zero
+            return np.zeros(shape=(r, 1))
+        proba = []
 
         self.classes = list(set().union(self.classes, np.unique(self.window.get_targets_matrix())))
 
@@ -223,7 +185,7 @@ class KNNClassifier(BaseSKMObject, ClassifierMixin):
                 votes[int(self.window.get_targets_matrix()[index])] += 1. / len(new_ind[i])
             proba.append(votes)
 
-        return np.array(proba)
+        return np.asarray(proba)
 
     def __predict_proba(self, X):
         """ __predict_proba

--- a/src/skmultiflow/lazy/knn_classifier.py
+++ b/src/skmultiflow/lazy/knn_classifier.py
@@ -156,7 +156,7 @@ class KNNClassifier(BaseSKMObject, ClassifierMixin):
         return np.array(predictions)
 
     def predict_proba(self, X):
-        """ Estimates the probability of each sample in X belonging to each of the class-labels.pyte
+        """ Estimates the probability of each sample in X belonging to each of the class-labels.
         
         Parameters
         ----------

--- a/src/skmultiflow/lazy/knn_classifier.py
+++ b/src/skmultiflow/lazy/knn_classifier.py
@@ -16,11 +16,12 @@ def KNN(n_neighbors=5, max_window_size=1000, leaf_size=30, nominal_attributes=No
 
 
 class KNNClassifier(BaseSKMObject, ClassifierMixin):
-    """ K-Nearest Neighbors classifier.
+    """ k-Nearest Neighbors classifier.
     
-    This non-parametric classification method keeps track of the last max_window_size
-    training samples. Predictions are obtained by aggregating the values of the
-    closest n_neighbors stored-samples with respect to the query sample.
+    This non-parametric classification method keeps a data window with the last max_window_size
+    training samples. The predicted class-label for a given query sample is obtained in two steps:
+    first, find the closest n_neighbors to the query sample in the data window. Second, aggregate
+    the class-labels of the n_neighbors to define the predicted class for the query sample.
 
     
     Parameters

--- a/src/skmultiflow/meta/classifier_chains.py
+++ b/src/skmultiflow/meta/classifier_chains.py
@@ -45,7 +45,7 @@ class ClassifierChain(BaseSKMObject, ClassifierMixin, MetaEstimatorMixin, MultiO
     >>> print(cc.predict(X))
     >>>
     >>> print("MCC")
-    >>> mcc = MCC(SGDClassifier(max_iter=100, loss='log', random_state=1), M=1000)
+    >>> mcc = MonteCarloClassifierChain(base_estimator=SGDClassifier(max_iter=100, loss='log', random_state=1), M=1000)
     >>> mcc.fit(X, Y)
     >>> Yp = mcc.predict(X, M=50)
     >>> print("with 50 iterations ...")

--- a/src/skmultiflow/meta/online_adac2.py
+++ b/src/skmultiflow/meta/online_adac2.py
@@ -107,7 +107,6 @@ class OnlineAdaC2Classifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixin):
         self.lam_sum = None
         self.wacc = None
         self.werr = None
-        self.__configure()
 
     def __configure(self):
         if hasattr(self.base_estimator, "reset"):
@@ -168,6 +167,9 @@ class OnlineAdaC2Classifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixin):
         self
 
         """
+        if self.ensemble is None:
+            self.__configure()
+
         if self.classes is None:
             if classes is None:
                 raise ValueError("The first partial_fit call should pass all the classes.")
@@ -306,26 +308,35 @@ class OnlineAdaC2Classifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixin):
         """
         proba = []
         r, c = get_dimensions(X)
-        try:
-            for i in range(self.actual_n_estimators):
-                partial_proba = self.ensemble[i].predict_proba(X)
-                if len(partial_proba[0]) > max(self.classes) + 1:
-                    raise ValueError("The number of classes in the base learner is larger than in the ensemble.")
 
-                if len(proba) < 1:
+        if self.ensemble is None:
+            return np.zeros((r, 1))
+
+        with warnings.catch_warnings():  # Context manager to catch errors raised by numpy as RuntimeWarning
+            warnings.filterwarnings('error')
+            try:
+                for i in range(self.actual_n_estimators):
+                    partial_proba = self.ensemble[i].predict_proba(X)
+                    if len(partial_proba[0]) > max(self.classes) + 1:
+                        raise ValueError("The number of classes in the base learner is larger than in the ensemble.")
+
+                    if len(proba) < 1:
+                        for n in range(r):
+                            proba.append([0.0 for _ in partial_proba[n]])
+
                     for n in range(r):
-                        proba.append([0.0 for _ in partial_proba[n]])
-
-                for n in range(r):
-                    for l in range(len(partial_proba[n])):
-                        try:
-                            proba[n][l] += np.log(self.wacc[i] / self.werr[i]) * partial_proba[n][l]
-                        except IndexError:
-                            proba[n].append(partial_proba[n][l])
-        except ValueError:
-            return np.zeros((r, 1))
-        except TypeError:
-            return np.zeros((r, 1))
+                        for l in range(len(partial_proba[n])):
+                            try:
+                                proba[n][l] += np.log(self.wacc[i] / self.werr[i]) * partial_proba[n][l]
+                            except IndexError:
+                                proba[n].append(partial_proba[n][l])
+                            except RuntimeWarning:
+                                # Catch division by zero errors raised by numpy as RuntimeWarning
+                                continue
+            except ValueError:
+                return np.zeros((r, 1))
+            except TypeError:
+                return np.zeros((r, 1))
 
         # normalizing probabilities
         sum_proba = []

--- a/src/skmultiflow/meta/online_boosting.py
+++ b/src/skmultiflow/meta/online_boosting.py
@@ -94,7 +94,6 @@ class OnlineBoostingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixi
         self.lam_sc = None
         self.lam_sw = None
         self.epsilon = None
-        self.__configure()
 
     def __configure(self):
         if hasattr(self.base_estimator, "reset"):
@@ -109,6 +108,7 @@ class OnlineBoostingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixi
         self.lam_sc = np.zeros(self.actual_n_estimators)
         self.lam_sw = np.zeros(self.actual_n_estimators)
         self.epsilon = np.zeros(self.actual_n_estimators)
+        self._is_empty = True
 
     def reset(self):
         self.__configure()
@@ -151,6 +151,9 @@ class OnlineBoostingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixi
         self
 
         """
+        if self.ensemble is None:
+            self.__configure()
+
         if self.classes is None:
             if classes is None:
                 raise ValueError("The first partial_fit call should pass all the classes.")
@@ -276,26 +279,36 @@ class OnlineBoostingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixi
         """
         proba = []
         r, c = get_dimensions(X)
-        try:
-            for i in range(self.actual_n_estimators):
-                partial_proba = self.ensemble[i].predict_proba(X)
-                if len(partial_proba[0]) > max(self.classes) + 1:
-                    raise ValueError("The number of classes in the base learner is larger than in the ensemble.")
 
-                if len(proba) < 1:
+        if self.ensemble is None:
+            return np.zeros((r, 1))
+
+        with warnings.catch_warnings():  # Context manager to catch errors raised by numpy as RuntimeWarning
+            warnings.filterwarnings('error')
+            try:
+                for i in range(self.actual_n_estimators):
+                    partial_proba = self.ensemble[i].predict_proba(X)
+                    if len(partial_proba[0]) > max(self.classes) + 1:
+                        raise ValueError("The number of classes in the base learner is larger than in the ensemble.")
+
+                    if len(proba) < 1:
+                        for n in range(r):
+                            proba.append([0.0 for _ in partial_proba[n]])
+
                     for n in range(r):
-                        proba.append([0.0 for _ in partial_proba[n]])
+                        for l in range(len(partial_proba[n])):
+                            try:
+                                proba[n][l] += np.log((1 - self.epsilon[i]) / self.epsilon[i]) * partial_proba[n][l]
+                            except IndexError:
+                                proba[n].append(partial_proba[n][l])
+                            except RuntimeWarning:
+                                # Catch division by zero errors raised by numpy as RuntimeWarning
+                                continue
 
-                for n in range(r):
-                    for l in range(len(partial_proba[n])):
-                        try:
-                            proba[n][l] += np.log((1 - self.epsilon[i]) / self.epsilon[i]) * partial_proba[n][l]
-                        except IndexError:
-                            proba[n].append(partial_proba[n][l])
-        except ValueError:
-            return np.zeros((r, 1))
-        except TypeError:
-            return np.zeros((r, 1))
+            except ValueError:
+                return np.zeros((r, 1))
+            except TypeError:
+                return np.zeros((r, 1))
 
         # normalizing probabilities
         sum_proba = []

--- a/src/skmultiflow/meta/online_boosting.py
+++ b/src/skmultiflow/meta/online_boosting.py
@@ -108,7 +108,6 @@ class OnlineBoostingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixi
         self.lam_sc = np.zeros(self.actual_n_estimators)
         self.lam_sw = np.zeros(self.actual_n_estimators)
         self.epsilon = np.zeros(self.actual_n_estimators)
-        self._is_empty = True
 
     def reset(self):
         self.__configure()

--- a/src/skmultiflow/meta/online_rus_boost.py
+++ b/src/skmultiflow/meta/online_rus_boost.py
@@ -129,7 +129,7 @@ class OnlineRUSBoostClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixi
     def reset(self):
         self.__configure()
 
-    def partial_fit(self, X, y, classes=None, weight=None):
+    def partial_fit(self, X, y, classes=None, sample_weight=None):
         """ Partially fits the model, based on the X and y matrix.
 
         Since it's an ensemble learner, if X and y matrix of more than one
@@ -220,7 +220,7 @@ class OnlineRUSBoostClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixi
                 k = self._random_state.poisson(lam_rus)
                 if k > 0:
                     for b in range(k):
-                        self.ensemble[i].partial_fit([X[j]], [y[j]], classes, weight)
+                        self.ensemble[i].partial_fit([X[j]], [y[j]], classes, sample_weight)
                 if self.ensemble[i].predict([X[j]])[0] == y[j]:
                     self.lam_sc[i] += lam
                     self.epsilon[i] = (self.lam_sw[i]) / (self.lam_sc[i] + self.lam_sw[i])

--- a/src/skmultiflow/meta/online_rus_boost.py
+++ b/src/skmultiflow/meta/online_rus_boost.py
@@ -106,7 +106,6 @@ class OnlineRUSBoostClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixi
         self.lam_neg = None
         self.lam_sw = None
         self.epsilon = None
-        self.__configure()
 
     def __configure(self):
         if hasattr(self.base_estimator, "reset"):
@@ -167,6 +166,9 @@ class OnlineRUSBoostClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixi
         self
 
         """
+        if self.ensemble is None:
+            self.__configure()
+
         if self.classes is None:
             if classes is None:
                 raise ValueError("The first partial_fit call should pass all the classes.")
@@ -325,26 +327,36 @@ class OnlineRUSBoostClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMixi
         """
         proba = []
         r, c = get_dimensions(X)
-        try:
-            for i in range(self.actual_n_estimators):
-                partial_proba = self.ensemble[i].predict_proba(X)
-                if len(partial_proba[0]) > max(self.classes) + 1:
-                    raise ValueError("The number of classes in the base learner is larger than in the ensemble.")
 
-                if len(proba) < 1:
+        if self.ensemble is None:
+            return np.zeros((r, 1))
+
+        with warnings.catch_warnings():   # Context manager to catch errors raised by numpy as RuntimeWarning
+            warnings.filterwarnings('error')
+            try:
+                for i in range(self.actual_n_estimators):
+                    partial_proba = self.ensemble[i].predict_proba(X)
+                    if len(partial_proba[0]) > max(self.classes) + 1:
+                        raise ValueError("The number of classes in the base learner is larger than in the ensemble.")
+
+                    if len(proba) < 1:
+                        for n in range(r):
+                            proba.append([0.0 for _ in partial_proba[n]])
+
                     for n in range(r):
-                        proba.append([0.0 for _ in partial_proba[n]])
+                        for l in range(len(partial_proba[n])):
+                            try:
+                                proba[n][l] += np.log((1 - self.epsilon[i]) / self.epsilon[i]) * partial_proba[n][l]
+                            except IndexError:
+                                proba[n].append(partial_proba[n][l])
+                            except RuntimeWarning:
+                                # Catch division by zero errors raised by numpy as RuntimeWarning
+                                continue
 
-                for n in range(r):
-                    for l in range(len(partial_proba[n])):
-                        try:
-                            proba[n][l] += np.log((1 - self.epsilon[i]) / self.epsilon[i]) * partial_proba[n][l]
-                        except IndexError:
-                            proba[n].append(partial_proba[n][l])
-        except ValueError:
-            return np.zeros((r, 1))
-        except TypeError:
-            return np.zeros((r, 1))
+            except ValueError:
+                return np.zeros((r, 1))
+            except TypeError:
+                return np.zeros((r, 1))
 
         # normalizing probabilities
         sum_proba = []

--- a/src/skmultiflow/meta/online_smote_bagging.py
+++ b/src/skmultiflow/meta/online_smote_bagging.py
@@ -89,7 +89,6 @@ class OnlineSMOTEBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimator
         self.classes = None
         self._random_state = None
         self.adwin_ensemble = None
-        self.__configure()
 
     def __configure(self):
         if hasattr(self.base_estimator, "reset"):
@@ -144,6 +143,9 @@ class OnlineSMOTEBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimator
         self
 
         """
+        if self.adwin_ensemble is None:
+            self.__configure()
+
         if self.classes is None:
             if classes is None:
                 raise ValueError("The first partial_fit call should pass all the classes.")
@@ -285,26 +287,36 @@ class OnlineSMOTEBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimator
         """
         proba = []
         r, c = get_dimensions(X)
-        try:
-            for i in range(self.actual_n_estimators):
-                partial_proba = self.ensemble[i].predict_proba(X)
-                if len(partial_proba[0]) > max(self.classes) + 1:
-                    raise ValueError("The number of classes in the base learner is larger than in the ensemble.")
 
-                if len(proba) < 1:
+        if self.adwin_ensemble is None:
+            return np.zeros((r, 1))
+
+        with warnings.catch_warnings():  # Context manager to catch errors raised by numpy as RuntimeWarning
+            warnings.filterwarnings('error')
+            try:
+                for i in range(self.actual_n_estimators):
+                    partial_proba = self.ensemble[i].predict_proba(X)
+                    if len(partial_proba[0]) > max(self.classes) + 1:
+                        raise ValueError("The number of classes in the base learner is larger than in the ensemble.")
+
+                    if len(proba) < 1:
+                        for n in range(r):
+                            proba.append([0.0 for _ in partial_proba[n]])
+
                     for n in range(r):
-                        proba.append([0.0 for _ in partial_proba[n]])
+                        for l in range(len(partial_proba[n])):
+                            try:
+                                proba[n][l] += partial_proba[n][l]
+                            except IndexError:
+                                proba[n].append(partial_proba[n][l])
+                            except RuntimeWarning:
+                                # Catch division by zero errors raised by numpy as RuntimeWarning
+                                continue
 
-                for n in range(r):
-                    for l in range(len(partial_proba[n])):
-                        try:
-                            proba[n][l] += partial_proba[n][l]
-                        except IndexError:
-                            proba[n].append(partial_proba[n][l])
-        except ValueError:
-            return np.zeros((r, 1))
-        except TypeError:
-            return np.zeros((r, 1))
+            except ValueError:
+                return np.zeros((r, 1))
+            except TypeError:
+                return np.zeros((r, 1))
 
         # normalizing probabilities
         sum_proba = []

--- a/src/skmultiflow/meta/online_smote_bagging.py
+++ b/src/skmultiflow/meta/online_smote_bagging.py
@@ -143,7 +143,7 @@ class OnlineSMOTEBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimator
         self
 
         """
-        if self.adwin_ensemble is None:
+        if self.ensemble is None:
             self.__configure()
 
         if self.classes is None:
@@ -288,7 +288,7 @@ class OnlineSMOTEBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimator
         proba = []
         r, c = get_dimensions(X)
 
-        if self.adwin_ensemble is None:
+        if self.ensemble is None:
             return np.zeros((r, 1))
 
         with warnings.catch_warnings():  # Context manager to catch errors raised by numpy as RuntimeWarning

--- a/src/skmultiflow/meta/online_under_over_bagging.py
+++ b/src/skmultiflow/meta/online_under_over_bagging.py
@@ -98,8 +98,6 @@ class OnlineUnderOverBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstim
         self.n_samples = None
         self.adwin_ensemble = None
 
-        self.__configure()
-
     def __configure(self):
         if hasattr(self.base_estimator, "reset"):
             self.base_estimator.reset()
@@ -147,6 +145,9 @@ class OnlineUnderOverBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstim
         passed in the first partial_fit call, or if they are passed in further
         calls but differ from the initial classes list passed..
         """
+        if self.adwin_ensemble is None:
+            self.__configure()
+
         if self.classes is None:
             if classes is None:
                 raise ValueError("The first partial_fit call should pass all the classes.")
@@ -263,26 +264,36 @@ class OnlineUnderOverBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstim
         """
         proba = []
         r, c = get_dimensions(X)
-        try:
-            for i in range(self.actual_n_estimators):
-                partial_proba = self.ensemble[i].predict_proba(X)
-                if len(partial_proba[0]) > max(self.classes) + 1:
-                    raise ValueError("The number of classes in the base learner is larger than in the ensemble.")
 
-                if len(proba) < 1:
+        if self.adwin_ensemble is None:
+            return np.zeros((r, 1))
+
+        with warnings.catch_warnings():  # Context manager to catch errors raised by numpy as RuntimeWarning
+            warnings.filterwarnings('error')
+            try:
+                for i in range(self.actual_n_estimators):
+                    partial_proba = self.ensemble[i].predict_proba(X)
+                    if len(partial_proba[0]) > max(self.classes) + 1:
+                        raise ValueError("The number of classes in the base learner is larger than in the ensemble.")
+
+                    if len(proba) < 1:
+                        for n in range(r):
+                            proba.append([0.0 for _ in partial_proba[n]])
+
                     for n in range(r):
-                        proba.append([0.0 for _ in partial_proba[n]])
+                        for l in range(len(partial_proba[n])):
+                            try:
+                                proba[n][l] += partial_proba[n][l]
+                            except IndexError:
+                                proba[n].append(partial_proba[n][l])
+                            except RuntimeWarning:
+                                # Catch division by zero errors raised by numpy as RuntimeWarning
+                                continue
 
-                for n in range(r):
-                    for l in range(len(partial_proba[n])):
-                        try:
-                            proba[n][l] += partial_proba[n][l]
-                        except IndexError:
-                            proba[n].append(partial_proba[n][l])
-        except ValueError:
-            return np.zeros((r, 1))
-        except TypeError:
-            return np.zeros((r, 1))
+            except ValueError:
+                return np.zeros((r, 1))
+            except TypeError:
+                return np.zeros((r, 1))
 
         # normalizing probabilities
         sum_proba = []

--- a/src/skmultiflow/meta/online_under_over_bagging.py
+++ b/src/skmultiflow/meta/online_under_over_bagging.py
@@ -145,7 +145,7 @@ class OnlineUnderOverBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstim
         passed in the first partial_fit call, or if they are passed in further
         calls but differ from the initial classes list passed..
         """
-        if self.adwin_ensemble is None:
+        if self.ensemble is None:
             self.__configure()
 
         if self.classes is None:
@@ -265,7 +265,7 @@ class OnlineUnderOverBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstim
         proba = []
         r, c = get_dimensions(X)
 
-        if self.adwin_ensemble is None:
+        if self.ensemble is None:
             return np.zeros((r, 1))
 
         with warnings.catch_warnings():  # Context manager to catch errors raised by numpy as RuntimeWarning

--- a/src/skmultiflow/rules/very_fast_decision_rules.py
+++ b/src/skmultiflow/rules/very_fast_decision_rules.py
@@ -449,7 +449,7 @@ class VeryFastDecisionRulesClassifier(BaseSKMObject, ClassifierMixin):
 
         return final_votes if fired_rule else self.default_rule.get_class_votes(X, self)
 
-    def partial_fit(self, X, y, classes=None, weight=None):
+    def partial_fit(self, X, y, classes=None, sample_weight=None):
         """Incrementally trains the model.
 
         Train samples (instances) are composed of X attributes and their corresponding targets y.
@@ -476,7 +476,7 @@ class VeryFastDecisionRulesClassifier(BaseSKMObject, ClassifierMixin):
         classes: list or numpy.array
             Contains the class values in the stream. If defined, will be used to define the length of the arrays
             returned by `predict_proba`
-        weight: float or array-like
+        sample_weight: float or array-like
             Instance weight. If not provided, uniform weights are assumed.
 
         Returns
@@ -488,13 +488,13 @@ class VeryFastDecisionRulesClassifier(BaseSKMObject, ClassifierMixin):
             self.classes = classes
         if y is not None:
             row_cnt, _ = get_dimensions(X)
-            if weight is None:
-                weight = np.ones(row_cnt)
-            if row_cnt != len(weight):
-                raise ValueError('Inconsistent number of instances ({}) and weights ({}).'.format(row_cnt, len(weight)))
+            if sample_weight is None:
+                sample_weight = np.ones(row_cnt)
+            if row_cnt != len(sample_weight):
+                raise ValueError('Inconsistent number of instances ({}) and weights ({}).'.format(row_cnt, len(sample_weight)))
             for i in range(row_cnt):
-                if weight[i] != 0.0:
-                    self._partial_fit(X[i], y[i], weight[i])
+                if sample_weight[i] != 0.0:
+                    self._partial_fit(X[i], y[i], sample_weight[i])
 
         return self
 


### PR DESCRIPTION
Stream estimators shall be able to return predictions at any time. Some methods were failing when predictions were requested and the model was empty. This PR addresses this issue for:
* `KNNClassifier`
* `OnlineAdaC2Classifier`
* `OnlineBoosting`
* `OnlineUnderOverBaggingClassifier`
* `OnlineSMOTEBaggingClassifier`
* `OnlineCSB2Classifier`

Changes proposed in this pull request:

- Return a default value (zero) for predictions if the model is empty.
- Update documentation of the KNNClassifier.
- Handle RuntimeWarning from numpy operations in `Online****`
- Fix typo in example code for `MonteCarloClassifierChain`
- Fixes #158

---

Checklist

- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] Tests are included for new functionality or updated accordingly.
- [x] Travis CI build passes with no errors.
- [ ] Test Coverage is maintained (threshold is -0.2%).
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).
