### PR TITLE
Fix bug in evaluators when model_size or running_time are listed first in the metrics option

### DIFF
--- a/src/skmultiflow/evaluation/base_evaluator.py
+++ b/src/skmultiflow/evaluation/base_evaluator.py
@@ -179,9 +179,14 @@ class StreamEvaluator(BaseSKMObject, metaclass=ABCMeta):
         # Metrics configuration
         self.metrics = [x.lower() for x in self.metrics]
 
-        for plot in self.metrics:
-            if plot not in constants.PLOT_TYPES:
-                raise ValueError('Plot type not supported: {}.'.format(plot))
+        for metric in self.metrics:
+            if metric not in constants.PLOT_TYPES:
+                raise ValueError('Metric type not supported: {}.'.format(metric))
+
+        # Re-order metrics list to ensure that metrics with plots come first
+        no_plot_metrics = {constants.MODEL_SIZE, constants.RUNNING_TIME}
+        metrics_set = set(self.metrics)
+        self.metrics = list(metrics_set.difference(no_plot_metrics)) + list(metrics_set.intersection(no_plot_metrics))
 
         # Check consistency between output type and metrics and between metrics
         if self._output_type == constants.SINGLE_OUTPUT:

--- a/src/skmultiflow/evaluation/base_evaluator.py
+++ b/src/skmultiflow/evaluation/base_evaluator.py
@@ -179,14 +179,18 @@ class StreamEvaluator(BaseSKMObject, metaclass=ABCMeta):
         # Metrics configuration
         self.metrics = [x.lower() for x in self.metrics]
 
+        metrics_with_plot = []
+        metrics_with_no_plot = []
         for metric in self.metrics:
             if metric not in constants.PLOT_TYPES:
                 raise ValueError('Metric type not supported: {}.'.format(metric))
+            if metric == constants.MODEL_SIZE or metric == constants.RUNNING_TIME:
+                metrics_with_no_plot.append(metric)
+            else:
+                metrics_with_plot.append(metric)
 
         # Re-order metrics list to ensure that metrics with plots come first
-        no_plot_metrics = {constants.MODEL_SIZE, constants.RUNNING_TIME}
-        metrics_set = set(self.metrics)
-        self.metrics = list(metrics_set.difference(no_plot_metrics)) + list(metrics_set.intersection(no_plot_metrics))
+        self.metrics = metrics_with_plot + metrics_with_no_plot
 
         # Check consistency between output type and metrics and between metrics
         if self._output_type == constants.SINGLE_OUTPUT:

--- a/src/skmultiflow/evaluation/evaluate_holdout.py
+++ b/src/skmultiflow/evaluation/evaluate_holdout.py
@@ -71,7 +71,7 @@ class EvaluateHoldout(StreamEvaluator):
         | 'average_mean_squared_error'
         | 'average_mean_absolute_error'
         | 'average_root_mean_square_error'
-        | **Experimental**
+        | **Experimental** (no plot generated)
         | 'running_time'
         | 'model_size'
 
@@ -95,6 +95,10 @@ class EvaluateHoldout(StreamEvaluator):
     -----
     1. This evaluator can process a single learner to track its performance; or multiple learners  at a time, to
        compare different models on the same stream.
+
+    2. The metrics `running_time` and `model_size ` are not plotted when the `show_plot` option is set. Only their
+       current value is displayed at the bottom of the figure. However, their values over the evaluation are written
+       into the resulting csv file if the `output_file` option is set.
 
     Examples
     --------

--- a/src/skmultiflow/evaluation/evaluate_prequential.py
+++ b/src/skmultiflow/evaluation/evaluate_prequential.py
@@ -69,7 +69,7 @@ class EvaluatePrequential(StreamEvaluator):
         | 'average_mean_squared_error'
         | 'average_mean_absolute_error'
         | 'average_root_mean_square_error'
-        | **Experimental**
+        | **Experimental** (no plot generated)
         | 'running_time'
         | 'model_size'
 
@@ -95,6 +95,10 @@ class EvaluatePrequential(StreamEvaluator):
 
     2. The metric 'true_vs_predicted' is intended to be informative only. It corresponds to evaluations at a specific
        moment which might not represent the actual learner performance across all instances.
+
+    3. The metrics `running_time` and `model_size ` are not plotted when the `show_plot` option is set. Only their
+       current value is displayed at the bottom of the figure. However, their values over the evaluation are written
+       into the resulting csv file if the `output_file` option is set.
 
     Examples
     --------


### PR DESCRIPTION
<!-- 
Thank you for contributing with a PR!

Please fill the description of change(s) and/or if it fixes an open issue (optional).

To ease the merge process please review the attached checklist.
-->

Changes proposed in this pull request:

- Fix bug in evaluators when model_size or running_time are listed first in the metrics option
- Update evaluators documentation to clarify that model_size and running_time are not plotted but their values can be retrieved via the output_file.
- Fixes #186 

---

Checklist

- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [ ] Tests are included for new functionality or updated accordingly.
- [ ] Travis CI build passes with no errors.
- [ ] Test Coverage is maintained (threshold is -0.2%).
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).
