### PR TITLE
Add check in InfoGainSplitCriterion to avoid division by zero

### DIFF
--- a/src/skmultiflow/trees/split_criterion/info_gain_split_criterion.py
+++ b/src/skmultiflow/trees/split_criterion/info_gain_split_criterion.py
@@ -62,7 +62,9 @@ class InfoGainSplitCriterion(SplitCriterion):
             dist_sums[i] = sum(distributions[i].values())
             total_weight += dist_sums[i]
         num_greater = 0
-        for d in dist_sums:
-            if (d / total_weight) > min_frac:
-                num_greater += 1
+
+        if total_weight > 0:
+            for d in dist_sums:
+                if (d / total_weight) > min_frac:
+                    num_greater += 1
         return num_greater


### PR DESCRIPTION
Changes proposed in this pull request:

* Add a check in `skmultiflow.trees.split_criterion.InfoGainSplitCriterion` to avoid potential division by zero.

---

Checklist

- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] Tests are included for new functionality or updated accordingly.
- [x] Travis CI build passes with no errors.
- [x] Test Coverage is maintained (threshold is -0.2%).
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).
