### PR TITLE
[BUG/ENHANCEMENT] Coverage tests for HAT/HATR and bug fixes

### DIFF
--- a/src/skmultiflow/trees/arf_hoeffding_tree.py
+++ b/src/skmultiflow/trees/arf_hoeffding_tree.py
@@ -1,6 +1,5 @@
 from skmultiflow.utils import check_random_state
-from skmultiflow.trees.hoeffding_tree import HoeffdingTreeClassifier, MAJORITY_CLASS, \
-    NAIVE_BAYES
+from skmultiflow.trees.hoeffding_tree import HoeffdingTreeClassifier
 from skmultiflow.trees.nodes import RandomLearningNodeClassification
 from skmultiflow.trees.nodes import RandomLearningNodeNB
 from skmultiflow.trees.nodes import RandomLearningNodeNBAdaptive
@@ -113,13 +112,13 @@ class ARFHoeffdingTreeClassifier(HoeffdingTreeClassifier):
         if initial_class_observations is None:
             initial_class_observations = {}
         # MAJORITY CLASS
-        if self._leaf_prediction == MAJORITY_CLASS:
+        if self._leaf_prediction == self._MAJORITY_CLASS:
             return RandomLearningNodeClassification(
                 initial_class_observations, self.max_features,
                 random_state=self._random_state
             )
         # NAIVE BAYES
-        elif self._leaf_prediction == NAIVE_BAYES:
+        elif self._leaf_prediction == self._NAIVE_BAYES:
             return RandomLearningNodeNB(
                 initial_class_observations, self.max_features,
                 random_state=self._random_state

--- a/src/skmultiflow/trees/extremely_fast_decision_tree.py
+++ b/src/skmultiflow/trees/extremely_fast_decision_tree.py
@@ -32,12 +32,6 @@ def HATT(max_byte_size=33554432, memory_estimate_period=1000000, grace_period=20
                                                nb_threshold=nb_threshold,
                                                nominal_attributes=nominal_attributes)
 
-GINI_SPLIT = 'gini'
-INFO_GAIN_SPLIT = 'info_gain'
-MAJORITY_CLASS = 'mc'
-NAIVE_BAYES = 'nb'
-NAIVE_BAYES_ADAPTIVE = 'nba'
-
 
 class ExtremelyFastDecisionTreeClassifier(HoeffdingTreeClassifier):
     """ Extremely Fast Decision Tree classifier.
@@ -90,14 +84,17 @@ class ExtremelyFastDecisionTreeClassifier(HoeffdingTreeClassifier):
 
     """
 
+    _GINI_SPLIT = 'gini'
+    _INFO_GAIN_SPLIT = 'info_gain'
+
     # Override _new_learning_node
     def _new_learning_node(self, initial_class_observations=None):
         """ Create a new learning node. The type of learning node depends on the tree configuration."""
         if initial_class_observations is None:
             initial_class_observations = {}
-        if self._leaf_prediction == MAJORITY_CLASS:
+        if self._leaf_prediction == self._MAJORITY_CLASS:
             return AnyTimeActiveLearningNode(initial_class_observations)
-        elif self._leaf_prediction == NAIVE_BAYES:
+        elif self._leaf_prediction == self._NAIVE_BAYES:
             return AnyTimeLearningNodeNB(initial_class_observations)
         else:  # NAIVE BAYES ADAPTIVE (default)
             return AnyTimeLearningNodeNBAdaptive(initial_class_observations)
@@ -355,9 +352,9 @@ class ExtremelyFastDecisionTreeClassifier(HoeffdingTreeClassifier):
 
         stop_flag = False
         if not node.observed_class_distribution_is_pure():
-            if self._split_criterion == GINI_SPLIT:
+            if self._split_criterion == self._GINI_SPLIT:
                 split_criterion = GiniSplitCriterion()
-            elif self._split_criterion == INFO_GAIN_SPLIT:
+            elif self._split_criterion == self._INFO_GAIN_SPLIT:
                 split_criterion = InfoGainSplitCriterion()
             else:
                 split_criterion = InfoGainSplitCriterion()
@@ -476,9 +473,9 @@ class ExtremelyFastDecisionTreeClassifier(HoeffdingTreeClassifier):
         """
 
         if not node.observed_class_distribution_is_pure():
-            if self._split_criterion == GINI_SPLIT:
+            if self._split_criterion == self._GINI_SPLIT:
                 split_criterion = GiniSplitCriterion()
-            elif self._split_criterion == INFO_GAIN_SPLIT:
+            elif self._split_criterion == self._INFO_GAIN_SPLIT:
                 split_criterion = InfoGainSplitCriterion()
             else:
                 split_criterion = InfoGainSplitCriterion()

--- a/src/skmultiflow/trees/hoeffding_adaptive_tree.py
+++ b/src/skmultiflow/trees/hoeffding_adaptive_tree.py
@@ -31,11 +31,6 @@ def HAT(max_byte_size=33554432, memory_estimate_period=1000000, grace_period=200
                                            bootstrap_sampling=bootstrap_sampling)
 
 
-MAJORITY_CLASS = 'mc'
-NAIVE_BAYES = 'nb'
-NAIVE_BAYES_ADAPTIVE = 'nba'
-
-
 class HoeffdingAdaptiveTreeClassifier(HoeffdingTreeClassifier):
     """ Hoeffding Adaptive Tree classifier.
 
@@ -125,7 +120,8 @@ class HoeffdingAdaptiveTreeClassifier(HoeffdingTreeClassifier):
     # == Hoeffding Adaptive Tree implementation ===
     # =============================================
 
-    ERROR_WIDTH_THRESHOLD = 300
+    _ERROR_WIDTH_THRESHOLD = 300
+
     def __init__(self,
                  max_byte_size=33554432,
                  memory_estimate_period=1000000,

--- a/src/skmultiflow/trees/hoeffding_adaptive_tree.py
+++ b/src/skmultiflow/trees/hoeffding_adaptive_tree.py
@@ -34,7 +34,6 @@ def HAT(max_byte_size=33554432, memory_estimate_period=1000000, grace_period=200
 MAJORITY_CLASS = 'mc'
 NAIVE_BAYES = 'nb'
 NAIVE_BAYES_ADAPTIVE = 'nba'
-ERROR_WIDTH_THRESHOLD = 300
 
 
 class HoeffdingAdaptiveTreeClassifier(HoeffdingTreeClassifier):
@@ -126,6 +125,7 @@ class HoeffdingAdaptiveTreeClassifier(HoeffdingTreeClassifier):
     # == Hoeffding Adaptive Tree implementation ===
     # =============================================
 
+    ERROR_WIDTH_THRESHOLD = 300
     def __init__(self,
                  max_byte_size=33554432,
                  memory_estimate_period=1000000,

--- a/src/skmultiflow/trees/hoeffding_adaptive_tree_regressor.py
+++ b/src/skmultiflow/trees/hoeffding_adaptive_tree_regressor.py
@@ -179,11 +179,6 @@ class HoeffdingAdaptiveTreeRegressor(HoeffdingTreeRegressor):
             self._active_leaf_node_cnt = 1
         self._tree_root.learn_from_instance(X, y, weight, self, None, -1)
 
-    def get_normalized_error(self, prediction, y):
-        normal_prediction = self.normalize_target_value(prediction)
-        normal_value = self.normalize_target_value(y)
-        return np.abs(normal_value-normal_prediction)
-
     def filter_instance_to_leaves(self, X, y, weight, split_parent, parent_branch, update_splitter_counts):
         nodes = []
         self._tree_root.filter_instance_to_leaves(X, y, weight, split_parent, parent_branch,

--- a/src/skmultiflow/trees/hoeffding_adaptive_tree_regressor.py
+++ b/src/skmultiflow/trees/hoeffding_adaptive_tree_regressor.py
@@ -8,7 +8,6 @@ import warnings
 
 _TARGET_MEAN = 'mean'
 _PERCEPTRON = 'perceptron'
-ERROR_WIDTH_THRESHOLD = 300
 
 
 def RegressionHAT(max_byte_size=33554432, memory_estimate_period=1000000, grace_period=200, split_confidence=0.0000001,
@@ -86,6 +85,7 @@ class HoeffdingAdaptiveTreeRegressor(HoeffdingTreeRegressor):
     # ======================================================
     # == Hoeffding Adaptive Tree Regressor implementation ==
     # ======================================================
+    ERROR_WIDTH_THRESHOLD = 300
 
     def __init__(self,
                  max_byte_size=33554432,

--- a/src/skmultiflow/trees/hoeffding_adaptive_tree_regressor.py
+++ b/src/skmultiflow/trees/hoeffding_adaptive_tree_regressor.py
@@ -8,9 +8,6 @@ from skmultiflow.utils import add_dict_values
 
 import warnings
 
-_TARGET_MEAN = 'mean'
-_PERCEPTRON = 'perceptron'
-
 
 def RegressionHAT(max_byte_size=33554432, memory_estimate_period=1000000, grace_period=200, split_confidence=0.0000001,
                   tie_threshold=0.05, binary_split=False, stop_mem_management=False, remove_poor_atts=False,
@@ -87,7 +84,7 @@ class HoeffdingAdaptiveTreeRegressor(HoeffdingTreeRegressor):
     # ======================================================
     # == Hoeffding Adaptive Tree Regressor implementation ==
     # ======================================================
-    ERROR_WIDTH_THRESHOLD = 300
+    _ERROR_WIDTH_THRESHOLD = 300
 
     def __init__(self,
                  max_byte_size=33554432,
@@ -133,9 +130,13 @@ class HoeffdingAdaptiveTreeRegressor(HoeffdingTreeRegressor):
 
     @leaf_prediction.setter
     def leaf_prediction(self, leaf_prediction):
-        if leaf_prediction not in {_TARGET_MEAN, _PERCEPTRON}:
-            print("Invalid leaf_prediction option {}', will use default '{}'".format(leaf_prediction, _PERCEPTRON))
-            self._leaf_prediction = _PERCEPTRON
+        if leaf_prediction not in {self._TARGET_MEAN, self._PERCEPTRON}:
+            print(
+                "Invalid leaf_prediction option {}', will use default '{}'".format(
+                    leaf_prediction, self._PERCEPTRON
+                )
+            )
+            self._leaf_prediction = self._PERCEPTRON
         else:
             self._leaf_prediction = leaf_prediction
 
@@ -185,7 +186,6 @@ class HoeffdingAdaptiveTreeRegressor(HoeffdingTreeRegressor):
                                                   update_splitter_counts, nodes)
         return nodes
 
-    # Override HoeffdingTreeClassifier
     def get_votes_for_instance(self, X):
         result = {}
         if self._tree_root is not None:

--- a/src/skmultiflow/trees/hoeffding_tree.py
+++ b/src/skmultiflow/trees/hoeffding_tree.py
@@ -47,13 +47,6 @@ def HoeffdingTree(max_byte_size=33554432, memory_estimate_period=1000000, grace_
                                    nb_threshold=nb_threshold,
                                    nominal_attributes=nominal_attributes)
 
-GINI_SPLIT = 'gini'
-INFO_GAIN_SPLIT = 'info_gain'
-HELLINGER = 'hellinger'
-MAJORITY_CLASS = 'mc'
-NAIVE_BAYES = 'nb'
-NAIVE_BAYES_ADAPTIVE = 'nba'
-
 
 class HoeffdingTreeClassifier(BaseSKMObject, ClassifierMixin):
     """ Hoeffding Tree or Very Fast Decision Tree classifier.
@@ -116,6 +109,14 @@ class HoeffdingTreeClassifier(BaseSKMObject, ClassifierMixin):
        MOA: Massive Online Analysis; Journal of Machine Learning Research 11: 1601-1604, 2010.
 
     """
+
+    _GINI_SPLIT = 'gini'
+    _INFO_GAIN_SPLIT = 'info_gain'
+    _HELLINGER = 'hellinger'
+    _MAJORITY_CLASS = 'mc'
+    _NAIVE_BAYES = 'nb'
+    _NAIVE_BAYES_ADAPTIVE = 'nba'
+
     # ====================================
     # == Hoeffding Tree implementation ===
     # ====================================
@@ -190,9 +191,14 @@ class HoeffdingTreeClassifier(BaseSKMObject, ClassifierMixin):
 
     @split_criterion.setter
     def split_criterion(self, split_criterion):
-        if split_criterion != GINI_SPLIT and split_criterion != INFO_GAIN_SPLIT and split_criterion != HELLINGER:
-            print("Invalid split_criterion option {}', will use default '{}'".format(split_criterion, INFO_GAIN_SPLIT))
-            self._split_criterion = INFO_GAIN_SPLIT
+        if split_criterion != self._GINI_SPLIT and split_criterion != self._INFO_GAIN_SPLIT \
+                and split_criterion != self._HELLINGER:
+            print(
+                "Invalid split_criterion option {}', will use default '{}'".format(
+                    split_criterion, self._INFO_GAIN_SPLIT
+                )
+            )
+            self._split_criterion = self._INFO_GAIN_SPLIT
         else:
             self._split_criterion = split_criterion
 
@@ -250,11 +256,14 @@ class HoeffdingTreeClassifier(BaseSKMObject, ClassifierMixin):
 
     @leaf_prediction.setter
     def leaf_prediction(self, leaf_prediction):
-        if leaf_prediction != MAJORITY_CLASS and leaf_prediction != NAIVE_BAYES \
-                and leaf_prediction != NAIVE_BAYES_ADAPTIVE:
-            print("Invalid leaf_prediction option {}', will use default '{}'".format(leaf_prediction,
-                                                                                     NAIVE_BAYES_ADAPTIVE))
-            self._leaf_prediction = NAIVE_BAYES_ADAPTIVE
+        if leaf_prediction != self._MAJORITY_CLASS and leaf_prediction != self._NAIVE_BAYES \
+                and leaf_prediction != self._NAIVE_BAYES_ADAPTIVE:
+            print(
+                "Invalid leaf_prediction option {}', will use default '{}'".format(
+                    leaf_prediction, self._NAIVE_BAYES_ADAPTIVE
+                )
+            )
+            self._leaf_prediction = self._NAIVE_BAYES_ADAPTIVE
         else:
             self._leaf_prediction = leaf_prediction
 
@@ -303,7 +312,7 @@ class HoeffdingTreeClassifier(BaseSKMObject, ClassifierMixin):
         self._active_leaf_byte_size_estimate = 0.0
         self._byte_size_estimate_overhead_fraction = 1.0
         self._growth_allowed = True
-        if self._leaf_prediction != MAJORITY_CLASS:
+        if self._leaf_prediction != self._MAJORITY_CLASS:
             self._remove_poor_atts = None
         self._train_weight_seen_by_model = 0.0
 
@@ -533,9 +542,9 @@ class HoeffdingTreeClassifier(BaseSKMObject, ClassifierMixin):
         """ Create a new learning node. The type of learning node depends on the tree configuration."""
         if initial_class_observations is None:
             initial_class_observations = {}
-        if self._leaf_prediction == MAJORITY_CLASS:
+        if self._leaf_prediction == self._MAJORITY_CLASS:
             return ActiveLearningNode(initial_class_observations)
-        elif self._leaf_prediction == NAIVE_BAYES:
+        elif self._leaf_prediction == self._NAIVE_BAYES:
             return LearningNodeNB(initial_class_observations)
         else:  # NAIVE BAYES ADAPTIVE (default)
             return LearningNodeNBAdaptive(initial_class_observations)
@@ -626,11 +635,11 @@ class HoeffdingTreeClassifier(BaseSKMObject, ClassifierMixin):
 
         """
         if not node.observed_class_distribution_is_pure():
-            if self._split_criterion == GINI_SPLIT:
+            if self._split_criterion == self._GINI_SPLIT:
                 split_criterion = GiniSplitCriterion()
-            elif self._split_criterion == INFO_GAIN_SPLIT:
+            elif self._split_criterion == self._INFO_GAIN_SPLIT:
                 split_criterion = InfoGainSplitCriterion()
-            elif self._split_criterion == HELLINGER:
+            elif self._split_criterion == self._HELLINGER:
                 split_criterion = HellingerDistanceCriterion()
             else:
                 split_criterion = InfoGainSplitCriterion()

--- a/src/skmultiflow/trees/hoeffding_tree_regressor.py
+++ b/src/skmultiflow/trees/hoeffding_tree_regressor.py
@@ -18,9 +18,6 @@ from skmultiflow.trees.nodes.active_learning_node_perceptron import compute_sd
 
 import warnings
 
-_TARGET_MEAN = 'mean'
-_PERCEPTRON = 'perceptron'
-
 
 def RegressionHoeffdingTree(max_byte_size=33554432, memory_estimate_period=1000000, grace_period=200,
                             split_confidence=0.0000001, tie_threshold=0.05, binary_split=False,
@@ -102,6 +99,9 @@ class HoeffdingTreeRegressor(RegressorMixin, HoeffdingTreeClassifier):
 
     """
 
+    _TARGET_MEAN = 'mean'
+    _PERCEPTRON = 'perceptron'
+
     # =============================================
     # == Hoeffding Tree Regressor implementation ==
     # =============================================
@@ -163,9 +163,13 @@ class HoeffdingTreeRegressor(RegressorMixin, HoeffdingTreeClassifier):
 
     @leaf_prediction.setter
     def leaf_prediction(self, leaf_prediction):
-        if leaf_prediction not in {_TARGET_MEAN, _PERCEPTRON}:
-            print("Invalid leaf_prediction option {}', will use default '{}'".format(leaf_prediction, _PERCEPTRON))
-            self._leaf_prediction = _PERCEPTRON
+        if leaf_prediction not in {self._TARGET_MEAN, self._PERCEPTRON}:
+            print(
+                "Invalid leaf_prediction option {}', will use default '{}'".format(
+                    leaf_prediction, self._PERCEPTRON
+                )
+            )
+            self._leaf_prediction = self._PERCEPTRON
         else:
             self._leaf_prediction = leaf_prediction
 
@@ -238,9 +242,9 @@ class HoeffdingTreeRegressor(RegressorMixin, HoeffdingTreeClassifier):
         """Create a new learning node. The type of learning node depends on the tree configuration."""
         if initial_class_observations is None:
             initial_class_observations = {}
-        if self.leaf_prediction == _TARGET_MEAN:
+        if self.leaf_prediction == self._TARGET_MEAN:
             return ActiveLearningNodeForRegression(initial_class_observations)
-        elif self.leaf_prediction == _PERCEPTRON:
+        elif self.leaf_prediction == self._PERCEPTRON:
             return ActiveLearningNodePerceptron(initial_class_observations, perceptron_node,
                                                 random_state=self.random_state)
 
@@ -391,7 +395,7 @@ class HoeffdingTreeRegressor(RegressorMixin, HoeffdingTreeClassifier):
         if self.samples_seen > 0:
             r, _ = get_dimensions(X)
             for i in range(r):
-                if self.leaf_prediction == _TARGET_MEAN:
+                if self.leaf_prediction == self._TARGET_MEAN:
                     votes = self.get_votes_for_instance(X[i])   # Gets observed data statistics
                     if votes == {}:
                         # Tree is empty, all target_values equal, default to zero
@@ -400,7 +404,7 @@ class HoeffdingTreeRegressor(RegressorMixin, HoeffdingTreeClassifier):
                         number_of_samples_seen = votes[0]
                         sum_of_values = votes[1]
                         predictions.append(sum_of_values / number_of_samples_seen)
-                elif self.leaf_prediction == _PERCEPTRON:
+                elif self.leaf_prediction == self._PERCEPTRON:
                     if self.samples_seen > 1:
                         perceptron_weights = self.get_weights_for_instance(X[i])
                         if perceptron_weights is None:
@@ -493,7 +497,7 @@ class HoeffdingTreeRegressor(RegressorMixin, HoeffdingTreeClassifier):
                 new_split = self.new_split_node(split_decision.split_test,
                                                 node.get_observed_class_distribution())
                 for i in range(split_decision.num_splits()):
-                    if self.leaf_prediction == _PERCEPTRON:
+                    if self.leaf_prediction == self._PERCEPTRON:
                         new_child = self._new_learning_node(split_decision.resulting_class_distribution_from_split(i),
                                                             node)
                     else:
@@ -524,7 +528,7 @@ class HoeffdingTreeRegressor(RegressorMixin, HoeffdingTreeClassifier):
             Parent node's branch index.
 
         """
-        if self.leaf_prediction == _TARGET_MEAN:
+        if self.leaf_prediction == self._TARGET_MEAN:
             new_leaf = InactiveLearningNodeForRegression(
                 to_deactivate.get_observed_class_distribution()
             )

--- a/src/skmultiflow/trees/isoup_tree.py
+++ b/src/skmultiflow/trees/isoup_tree.py
@@ -22,11 +22,6 @@ from skmultiflow.trees.nodes import InactiveLearningNodeAdaptiveMultiTarget
 import warnings
 
 
-_TARGET_MEAN = 'mean'
-_PERCEPTRON = 'perceptron'
-_ADAPTIVE = 'adaptive'
-
-
 def MultiTargetRegressionHoeffdingTree(max_byte_size=33554432, memory_estimate_period=1000000, grace_period=200,
                                        split_confidence=0.0000001, tie_threshold=0.05, binary_split=False,
                                        stop_mem_management=False, remove_poor_atts=False, leaf_prediction='perceptron',
@@ -107,6 +102,8 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, MultiOutputMixin):
        Journal of Intelligent Information Systems 50.2 (2018): 315-339.
     """
 
+    _ADAPTIVE = 'adaptive'
+
     # ============================================================
     # == Multi-target Regression Hoeffding Tree implementation ===
     # ============================================================
@@ -171,9 +168,13 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, MultiOutputMixin):
 
     @leaf_prediction.setter
     def leaf_prediction(self, leaf_prediction):
-        if leaf_prediction not in {_TARGET_MEAN, _PERCEPTRON, _ADAPTIVE}:
-            print("Invalid leaf_prediction option {}', will use default '{}'".format(leaf_prediction, _PERCEPTRON))
-            self._leaf_prediction = _PERCEPTRON
+        if leaf_prediction not in {self._TARGET_MEAN, self._PERCEPTRON, self._ADAPTIVE}:
+            print(
+                "Invalid leaf_prediction option {}', will use default '{}'".format(
+                    leaf_prediction, self._PERCEPTRON
+                )
+            )
+            self._leaf_prediction = self._PERCEPTRON
         else:
             self._leaf_prediction = leaf_prediction
 
@@ -265,17 +266,17 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, MultiOutputMixin):
         """
         if initial_class_observations is None:
             initial_class_observations = {}
-        if self.leaf_prediction == _TARGET_MEAN:
+        if self.leaf_prediction == self._TARGET_MEAN:
             return ActiveLearningNodeForRegressionMultiTarget(
                 initial_class_observations
             )
-        elif self.leaf_prediction == _PERCEPTRON:
+        elif self.leaf_prediction == self._PERCEPTRON:
             return ActiveLearningNodePerceptronMultiTarget(
                 initial_class_observations,
                 perceptron_weight,
                 self.random_state
             )
-        elif self.leaf_prediction == _ADAPTIVE:
+        elif self.leaf_prediction == self._ADAPTIVE:
             return ActiveLearningNodeAdaptiveMultiTarget(
                 initial_class_observations,
                 perceptron_weight,
@@ -480,7 +481,7 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, MultiOutputMixin):
         except AttributeError:
             return [0.0]
         for i in range(r):
-            if self.leaf_prediction == _TARGET_MEAN:
+            if self.leaf_prediction == self._TARGET_MEAN:
                 votes = self.get_votes_for_instance(X[i]).copy()
                 # Tree is not empty, otherwise, all target_values are set
                 # equally, default to zero
@@ -488,7 +489,7 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, MultiOutputMixin):
                     number_of_examples_seen = votes[0]
                     sum_of_values = votes[1]
                     predictions[i] = sum_of_values / number_of_examples_seen
-            elif self.leaf_prediction == _PERCEPTRON:
+            elif self.leaf_prediction == self._PERCEPTRON:
                 if self.examples_seen > 1:
                     perceptron_weights = self.get_weights_for_instance(X[i])
                     if perceptron_weights is None:
@@ -514,7 +515,7 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, MultiOutputMixin):
                     # Samples are normalized using just one sd, as proposed in
                     # the iSoup-Tree method
                     predictions[i] = normalized_prediction * sd + mean
-            elif self.leaf_prediction == _ADAPTIVE:
+            elif self.leaf_prediction == self._ADAPTIVE:
                 if self.examples_seen > 1:
                     # Mean predictor
                     votes = self.get_votes_for_instance(X[i]).copy()
@@ -637,18 +638,18 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, MultiOutputMixin):
                     node.get_observed_class_distribution()
                 )
                 for i in range(split_decision.num_splits()):
-                    if self.leaf_prediction == _PERCEPTRON:
+                    if self.leaf_prediction == self._PERCEPTRON:
                         new_child = self._new_learning_node(
                             split_decision.
                             resulting_class_distribution_from_split(i),
                             node.perceptron_weight
                         )
-                    elif self.leaf_prediction == _TARGET_MEAN:
+                    elif self.leaf_prediction == self._TARGET_MEAN:
                         new_child = self._new_learning_node(
                             split_decision.
                             resulting_class_distribution_from_split(i),
                             None)
-                    elif self.leaf_prediction == _ADAPTIVE:
+                    elif self.leaf_prediction == self._ADAPTIVE:
                         new_child = self._new_learning_node(
                             split_decision.
                             resulting_class_distribution_from_split(i),
@@ -686,17 +687,17 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, MultiOutputMixin):
         parent_branch: int
             Parent node's branch index.
         """
-        if self.leaf_prediction == _TARGET_MEAN:
+        if self.leaf_prediction == self._TARGET_MEAN:
             new_leaf = InactiveLearningNodeForRegression(
                 to_deactivate.get_observed_class_distribution()
             )
-        elif self.leaf_prediction == _PERCEPTRON:
+        elif self.leaf_prediction == self._PERCEPTRON:
             new_leaf = InactiveLearningNodePerceptronMultiTarget(
                 to_deactivate.get_observed_class_distribution(),
                 to_deactivate.perceptron_weight,
                 to_deactivate.random_state
             )
-        elif self.leaf_prediction == _ADAPTIVE:
+        elif self.leaf_prediction == self._ADAPTIVE:
             new_leaf = InactiveLearningNodeAdaptiveMultiTarget(
                 to_deactivate.get_observed_class_distribution(),
                 to_deactivate.perceptron_weight,

--- a/src/skmultiflow/trees/label_combination_hoeffding_tree.py
+++ b/src/skmultiflow/trees/label_combination_hoeffding_tree.py
@@ -34,11 +34,6 @@ def LCHT(max_byte_size=33554432, memory_estimate_period=1000000, grace_period=20
                                                    n_labels=n_labels)
 
 
-MAJORITY_CLASS = 'mc'
-NAIVE_BAYES = 'nb'
-NAIVE_BAYES_ADAPTIVE = 'nba'
-
-
 class LabelCombinationHoeffdingTreeClassifier(HoeffdingTreeClassifier, MultiOutputMixin):
     """ Label Combination Hoeffding Tree for multi-label classification.
 
@@ -179,9 +174,9 @@ class LabelCombinationHoeffdingTreeClassifier(HoeffdingTreeClassifier, MultiOutp
         """Create a new learning node. The type of learning node depends on the tree configuration."""
         if initial_class_observations is None:
             initial_class_observations = {}
-        if self._leaf_prediction == MAJORITY_CLASS:
+        if self._leaf_prediction == self._MAJORITY_CLASS:
             return LCActiveLearningNode(initial_class_observations)
-        elif self._leaf_prediction == NAIVE_BAYES:
+        elif self._leaf_prediction == self._NAIVE_BAYES:
             return LCLearningNodeNB(initial_class_observations)
         else:  # NAIVE BAYES ADAPTIVE (default)
             return LCLearningNodeNBA(initial_class_observations)

--- a/src/skmultiflow/trees/nodes/ada_learning_node.py
+++ b/src/skmultiflow/trees/nodes/ada_learning_node.py
@@ -7,10 +7,6 @@ from skmultiflow.trees.nodes import AdaNode
 
 from skmultiflow.utils import get_max_value_key, normalize_values_in_dict
 
-MAJORITY_CLASS = 'mc'
-NAIVE_BAYES = 'nb'
-NAIVE_BAYES_ADAPTIVE = 'nba'
-
 
 class AdaLearningNode(LearningNodeNBAdaptive, AdaNode):
     """ Learning node for Hoeffding Adaptive Tree that uses Adaptive Naive
@@ -88,24 +84,30 @@ class AdaLearningNode(LearningNodeNBAdaptive, AdaNode):
             self.set_weight_seen_at_last_split_evaluation(weight_seen)
 
     # Override LearningNodeNBAdaptive
-    def get_class_votes(self, X, ht):
+    def get_class_votes(self, X, hat):
         # dist = {}
-        prediction_option = ht.leaf_prediction
+        prediction_option = hat.leaf_prediction
         # MC
-        if prediction_option == MAJORITY_CLASS:
+        if prediction_option == hat._MAJORITY_CLASS:
             dist = self.get_observed_class_distribution()
         # NB
-        elif prediction_option == NAIVE_BAYES:
-            dist = do_naive_bayes_prediction(X, self._observed_class_distribution, self._attribute_observers)
+        elif prediction_option == hat._NAIVE_BAYES:
+            dist = do_naive_bayes_prediction(
+                X, self._observed_class_distribution, self._attribute_observers
+            )
         # NBAdaptive (default)
         else:
             if self._mc_correct_weight > self._nb_correct_weight:
                 dist = self.get_observed_class_distribution()
             else:
-                dist = do_naive_bayes_prediction(X, self._observed_class_distribution, self._attribute_observers)
+                dist = do_naive_bayes_prediction(
+                    X, self._observed_class_distribution,
+                    self._attribute_observers
+                )
 
         dist_sum = sum(dist.values())  # sum all values in dictionary
-        normalization_factor = dist_sum * self.get_error_estimation() * self.get_error_estimation()
+        normalization_factor = dist_sum * self.get_error_estimation() * \
+            self.get_error_estimation()
 
         if normalization_factor > 0.0:
             dist = normalize_values_in_dict(dist, normalization_factor, inplace=False)

--- a/src/skmultiflow/trees/nodes/ada_learning_node.py
+++ b/src/skmultiflow/trees/nodes/ada_learning_node.py
@@ -10,7 +10,6 @@ from skmultiflow.utils import get_max_value_key, normalize_values_in_dict
 MAJORITY_CLASS = 'mc'
 NAIVE_BAYES = 'nb'
 NAIVE_BAYES_ADAPTIVE = 'nba'
-ERROR_WIDTH_THRESHOLD = 300
 
 
 class AdaLearningNode(LearningNodeNBAdaptive, AdaNode):

--- a/src/skmultiflow/trees/nodes/ada_split_node.py
+++ b/src/skmultiflow/trees/nodes/ada_split_node.py
@@ -87,8 +87,8 @@ class AdaSplitNode(SplitNode, AdaNode):
 
         # Condition to replace alternate tree
         elif self._alternate_tree is not None and not self._alternate_tree.is_null_error():
-            if self.get_error_width() > hat.ERROR_WIDTH_THRESHOLD \
-                    and self._alternate_tree.get_error_width() > hat.ERROR_WIDTH_THRESHOLD:
+            if self.get_error_width() > hat._ERROR_WIDTH_THRESHOLD \
+                    and self._alternate_tree.get_error_width() > hat._ERROR_WIDTH_THRESHOLD:
                 old_error_rate = self.get_error_estimation()
                 alt_error_rate = self._alternate_tree.get_error_estimation()
                 fDelta = .05

--- a/src/skmultiflow/trees/nodes/ada_split_node.py
+++ b/src/skmultiflow/trees/nodes/ada_split_node.py
@@ -139,12 +139,12 @@ class AdaSplitNode(SplitNode, AdaNode):
 
     # Override AdaNode
     def kill_tree_children(self, hat):
-        for child in self._children:
+        for child in self._children.values():
             if child is not None:
                 # Delete alternate tree if it exists
                 if isinstance(child, SplitNode) and child._alternate_tree is not None:
                     child._alternate_tree.kill_tree_children(hat)
-                    self._pruned_alternate_trees += 1
+                    hat.pruned_alternate_trees_cnt += 1
                 # Recursive delete of SplitNodes
                 if isinstance(child, SplitNode):
                     child.kill_tree_children(hat)

--- a/src/skmultiflow/trees/nodes/ada_split_node.py
+++ b/src/skmultiflow/trees/nodes/ada_split_node.py
@@ -10,8 +10,6 @@ from skmultiflow.trees.attribute_test import NominalAttributeMultiwayTest
 from skmultiflow.drift_detection import ADWIN
 from skmultiflow.utils import check_random_state, get_max_value_key
 
-ERROR_WIDTH_THRESHOLD = 300
-
 
 class AdaSplitNode(SplitNode, AdaNode):
     """ Node that splits the data in a Hoeffding Adaptive Tree.
@@ -89,12 +87,12 @@ class AdaSplitNode(SplitNode, AdaNode):
 
         # Condition to replace alternate tree
         elif self._alternate_tree is not None and not self._alternate_tree.is_null_error():
-            if self.get_error_width() > ERROR_WIDTH_THRESHOLD \
-                    and self._alternate_tree.get_error_width() > ERROR_WIDTH_THRESHOLD:
+            if self.get_error_width() > hat.ERROR_WIDTH_THRESHOLD \
+                    and self._alternate_tree.get_error_width() > hat.ERROR_WIDTH_THRESHOLD:
                 old_error_rate = self.get_error_estimation()
                 alt_error_rate = self._alternate_tree.get_error_estimation()
                 fDelta = .05
-                fN = 1.0 / self._alternate_tree.get_error_width() + 1.0 / (self.get_error_width())
+                fN = 1.0 / self._alternate_tree.get_error_width() + 1.0 / self.get_error_width()
 
                 bound = math.sqrt(2.0 * old_error_rate * (1.0 - old_error_rate) * math.log(2.0 / fDelta) * fN)
                 # To check, bound never less than (old_error_rate - alt_error_rate)

--- a/src/skmultiflow/trees/nodes/ada_split_node_for_regression.py
+++ b/src/skmultiflow/trees/nodes/ada_split_node_for_regression.py
@@ -10,8 +10,6 @@ from skmultiflow.trees.nodes import AdaNode
 from skmultiflow.drift_detection.adwin import ADWIN
 from skmultiflow.utils import check_random_state
 
-ERROR_WIDTH_THRESHOLD = 300
-
 
 class AdaSplitNodeForRegression(SplitNode, AdaNode):
     """ Node that splits the data in a Regression Hoeffding Adaptive Tree.
@@ -90,12 +88,12 @@ class AdaSplitNodeForRegression(SplitNode, AdaNode):
 
         # Condition to replace alternate tree
         elif self._alternate_tree is not None and not self._alternate_tree.is_null_error():
-            if self.get_error_width() > ERROR_WIDTH_THRESHOLD \
-                    and self._alternate_tree.get_error_width() > ERROR_WIDTH_THRESHOLD:
+            if self.get_error_width() > rhat.ERROR_WIDTH_THRESHOLD \
+                    and self._alternate_tree.get_error_width() > rhat.ERROR_WIDTH_THRESHOLD:
                 old_error_rate = self.get_error_estimation()
                 alt_error_rate = self._alternate_tree.get_error_estimation()
                 fDelta = .05
-                fN = 1.0 / self._alternate_tree.get_error_width() + 1.0 / (self.get_error_width())
+                fN = 1.0 / self._alternate_tree.get_error_width() + 1.0 / self.get_error_width()
 
                 bound = math.sqrt(2.0 * old_error_rate * (1.0 - old_error_rate) * math.log(2.0 / fDelta) * fN)
                 # To check, bound never less than (old_error_rate - alt_error_rate)
@@ -112,7 +110,7 @@ class AdaSplitNodeForRegression(SplitNode, AdaNode):
                 elif bound < alt_error_rate - old_error_rate:
                     if isinstance(self._alternate_tree, ActiveLearningNode):
                         self._alternate_tree = None
-                    elif isinstance(self._alternate_tree, ActiveLearningNode):
+                    elif isinstance(self._alternate_tree, InactiveLearningNode):
                         self._alternate_tree = None
                     else:
                         self._alternate_tree.kill_tree_children(rhat)

--- a/src/skmultiflow/trees/nodes/ada_split_node_for_regression.py
+++ b/src/skmultiflow/trees/nodes/ada_split_node_for_regression.py
@@ -89,8 +89,8 @@ class AdaSplitNodeForRegression(SplitNode, AdaNode):
 
         # Condition to replace alternate tree
         elif self._alternate_tree is not None and not self._alternate_tree.is_null_error():
-            if self.get_error_width() > rhat.ERROR_WIDTH_THRESHOLD \
-                    and self._alternate_tree.get_error_width() > rhat.ERROR_WIDTH_THRESHOLD:
+            if self.get_error_width() > rhat._ERROR_WIDTH_THRESHOLD \
+                    and self._alternate_tree.get_error_width() > rhat._ERROR_WIDTH_THRESHOLD:
                 old_error_rate = self.get_error_estimation()
                 alt_error_rate = self._alternate_tree.get_error_estimation()
                 fDelta = .05

--- a/src/skmultiflow/trees/nodes/ada_split_node_for_regression.py
+++ b/src/skmultiflow/trees/nodes/ada_split_node_for_regression.py
@@ -140,11 +140,11 @@ class AdaSplitNodeForRegression(SplitNode, AdaNode):
 
     # Override AdaNode
     def kill_tree_children(self, rhat):
-        for child in self._children:
+        for child in self._children.values():
             if child is not None:
                 # Delete alternate tree if it exists
                 if isinstance(child, SplitNode) and child._alternate_tree is not None:
-                    self._pruned_alternate_trees += 1
+                    rhat.pruned_alternate_trees_cnt += 1
                 # Recursive delete of SplitNodes
                 if isinstance(child, SplitNode):
                     child.kill_tree_children(rhat)

--- a/src/skmultiflow/trees/nodes/lc_active_learning_node.py
+++ b/src/skmultiflow/trees/nodes/lc_active_learning_node.py
@@ -2,8 +2,6 @@ from skmultiflow.trees.attribute_observer import NumericAttributeClassObserverGa
 from skmultiflow.trees.attribute_observer import NominalAttributeClassObserver
 from skmultiflow.trees.nodes import ActiveLearningNode
 
-NAIVE_BAYES_ADAPTIVE = 'nba'
-
 
 class LCActiveLearningNode(ActiveLearningNode):
     """ Active Learning node for the Label Combination Hoeffding Tree.
@@ -19,7 +17,7 @@ class LCActiveLearningNode(ActiveLearningNode):
 
     def learn_from_instance(self, X, y, weight, ht):
 
-        if not(ht.leaf_prediction == NAIVE_BAYES_ADAPTIVE):
+        if ht.leaf_prediction != ht._NAIVE_BAYES_ADAPTIVE:
             y = ''.join(str(e) for e in y)
             y = int(y, 2)
 

--- a/src/skmultiflow/trees/stacked_single_target_hoeffding_tree_regressor.py
+++ b/src/skmultiflow/trees/stacked_single_target_hoeffding_tree_regressor.py
@@ -16,10 +16,6 @@ from skmultiflow.trees.nodes import SSTInactiveLearningNode
 from skmultiflow.trees.nodes import SSTInactiveLearningNodeAdaptive
 
 
-_PERCEPTRON = 'perceptron'
-_ADAPTIVE = 'adaptive'
-
-
 class StackedSingleTargetHoeffdingTreeRegressor(iSOUPTreeRegressor, MultiOutputMixin):
     """Stacked Single-target Hoeffding Tree regressor.
 
@@ -141,9 +137,13 @@ class StackedSingleTargetHoeffdingTreeRegressor(iSOUPTreeRegressor, MultiOutputM
 
     @leaf_prediction.setter
     def leaf_prediction(self, leaf_prediction):
-        if leaf_prediction not in {_PERCEPTRON, _ADAPTIVE}:
-            print("Invalid leaf_prediction option {}', will use default '{}'".format(leaf_prediction, _PERCEPTRON))
-            self._leaf_prediction = _PERCEPTRON
+        if leaf_prediction not in {self._PERCEPTRON, self._ADAPTIVE}:
+            print(
+                "Invalid leaf_prediction option {}', will use default '{}'".format(
+                    leaf_prediction, self._PERCEPTRON
+                )
+            )
+            self._leaf_prediction = self._PERCEPTRON
         else:
             self._leaf_prediction = leaf_prediction
 
@@ -185,13 +185,13 @@ class StackedSingleTargetHoeffdingTreeRegressor(iSOUPTreeRegressor, MultiOutputM
         """
         if initial_class_observations is None:
             initial_class_observations = {}
-        if self.leaf_prediction == _PERCEPTRON:
+        if self.leaf_prediction == self._PERCEPTRON:
             return SSTActiveLearningNode(
                 initial_class_observations,
                 perceptron_weight,
                 self.random_state
             )
-        elif self.leaf_prediction == _ADAPTIVE:
+        elif self.leaf_prediction == self._ADAPTIVE:
             return SSTActiveLearningNodeAdaptive(
                 initial_class_observations,
                 perceptron_weight,
@@ -218,7 +218,7 @@ class StackedSingleTargetHoeffdingTreeRegressor(iSOUPTreeRegressor, MultiOutputM
         except AttributeError:
             return [0.0]
         for i in range(r):
-            if self.leaf_prediction == _PERCEPTRON:
+            if self.leaf_prediction == self._PERCEPTRON:
                 if self.examples_seen > 1:
                     perceptron_weights = self.get_weights_for_instance(X[i])
                     if perceptron_weights is None:
@@ -248,7 +248,7 @@ class StackedSingleTargetHoeffdingTreeRegressor(iSOUPTreeRegressor, MultiOutputM
                     # Samples are normalized using just one sd, as proposed in
                     # the iSoup-Tree method
                     predictions[i] = normalized_meta_prediction * sd + mean
-            elif self.leaf_prediction == _ADAPTIVE:
+            elif self.leaf_prediction == self._ADAPTIVE:
                 if self.examples_seen > 1:
                     # Mean predictor
                     votes = self.get_votes_for_instance(X[i]).copy()
@@ -397,13 +397,13 @@ class StackedSingleTargetHoeffdingTreeRegressor(iSOUPTreeRegressor, MultiOutputM
                     node.get_observed_class_distribution()
                 )
                 for i in range(split_decision.num_splits()):
-                    if self.leaf_prediction == _PERCEPTRON:
+                    if self.leaf_prediction == self._PERCEPTRON:
                         new_child = self._new_learning_node(
                             split_decision.
                             resulting_class_distribution_from_split(i),
                             node.perceptron_weight
                         )
-                    elif self.leaf_prediction == _ADAPTIVE:
+                    elif self.leaf_prediction == self._ADAPTIVE:
                         new_child = self._new_learning_node(
                             split_decision.
                             resulting_class_distribution_from_split(i),
@@ -443,12 +443,12 @@ class StackedSingleTargetHoeffdingTreeRegressor(iSOUPTreeRegressor, MultiOutputM
         parent_branch: int
             Parent node's branch index.
         """
-        if self.leaf_prediction == _PERCEPTRON:
+        if self.leaf_prediction == self._PERCEPTRON:
             new_leaf = SSTInactiveLearningNode(
                 to_deactivate.get_observed_class_distribution(),
                 to_deactivate.perceptron_weight
             )
-        elif self.leaf_prediction == _ADAPTIVE:
+        elif self.leaf_prediction == self._ADAPTIVE:
             new_leaf = SSTInactiveLearningNodeAdaptive(
                 to_deactivate.get_observed_class_distribution(),
                 to_deactivate.perceptron_weight

--- a/tests/trees/test_hoeffding_adaptive_tree.py
+++ b/tests/trees/test_hoeffding_adaptive_tree.py
@@ -195,9 +195,26 @@ def test_hoeffding_adaptive_tree_alternate_tree():
             stream.generate_drift()
             change_point1 = float('Inf')
 
+            expected_description = "if Attribute 2 <= 63.63636363636363:\n" \
+                                   "  if Attribute 2 <= 39.54545454545455:\n" \
+                                   "    Leaf = Class 0 | {0: 397.5023676194098}\n" \
+                                   "  if Attribute 2 > 39.54545454545455:\n" \
+                                   "    if Attribute 2 <= 58.81818181818181:\n" \
+                                   "      Leaf = Class 1 | {1: 299.8923824199619}\n" \
+                                   "    if Attribute 2 > 58.81818181818181:\n" \
+                                   "      Leaf = Class 0 | {0: 54.0, 1: 20.107617580038095}\n" \
+                                   "if Attribute 2 > 63.63636363636363:\n" \
+                                   "  Leaf = Class 0 | {0: 512.5755895049351}\n"
+            assert expected_description == learner.get_model_description()
+
         if cnt > change_point2:
             stream.generate_drift()
             change_point2 = float('Inf')
+            expected_description = "if Attribute 8 <= 268547.7178694747:\n" \
+                                   "  Leaf = Class 0 | {0: 446.18690518790413, 1: 80.6180778406834}\n" \
+                                   "if Attribute 8 > 268547.7178694747:\n" \
+                                   "  Leaf = Class 1 | {0: 36.8130948120959, 1: 356.38192215931656}\n"
+            assert expected_description == learner.get_model_description()
 
         if cnt > change_point3:
             stream.generate_drift()

--- a/tests/trees/test_regression_hoeffding_adaptive_tree.py
+++ b/tests/trees/test_regression_hoeffding_adaptive_tree.py
@@ -167,3 +167,26 @@ def test_regression_hoeffding_adaptive_tree_categorical_features(test_path):
     assert SequenceMatcher(
         None, expected_description, learner.get_model_description()
     ).ratio() > 0.9
+
+
+def test_hoeffding_adaptive_tree_regressor_alternate_tree():
+    stream = RegressionGenerator(
+        n_samples=3000, n_features=10, n_informative=7, random_state=7
+    )
+
+    learner = HoeffdingAdaptiveTreeRegressor(leaf_prediction='mean')
+
+    cnt = 0
+    change_point = 1500
+    max_samples = 4000
+
+    while cnt < max_samples:
+        X, y = stream.next_sample()
+
+        learner.partial_fit(X, y)
+        cnt += 1
+
+        if cnt > change_point:
+            stream = RegressionGenerator(
+                n_samples=3000, n_features=10, n_informative=3, random_state=8
+            )

--- a/tests/trees/test_regression_hoeffding_adaptive_tree.py
+++ b/tests/trees/test_regression_hoeffding_adaptive_tree.py
@@ -170,23 +170,74 @@ def test_regression_hoeffding_adaptive_tree_categorical_features(test_path):
 
 
 def test_hoeffding_adaptive_tree_regressor_alternate_tree():
-    stream = RegressionGenerator(
-        n_samples=3000, n_features=10, n_informative=7, random_state=7
+    np.random.seed(8)
+
+    learner = HoeffdingAdaptiveTreeRegressor(
+        leaf_prediction='mean', grace_period=1000
     )
 
-    learner = HoeffdingAdaptiveTreeRegressor(leaf_prediction='mean')
-
+    max_samples = 7000
     cnt = 0
-    change_point = 1500
-    max_samples = 4000
+
+    p1 = False
+    p2 = False
 
     while cnt < max_samples:
-        X, y = stream.next_sample()
+        X = [np.random.uniform(low=-1, high=1, size=2)]
+
+        if cnt < 4000:
+            if X[0][0] <= 0 and X[0][1] > 0:
+                y = [np.random.normal(loc=-3, scale=1)]
+            elif X[0][0] > 0 and X[0][1] > 0:
+                y = [np.random.normal(loc=3, scale=1)]
+            elif X[0][0] <= 0 and X[0][1] <= 0:
+                y = [np.random.normal(loc=3, scale=1)]
+            else:
+                y = [np.random.normal(loc=-3, scale=1)]
+        elif cnt < 5000:
+            if not p1:
+                expected_info = "if Attribute 1 <= -0.347867256929453:\n" \
+                                "  Leaf = Statistics {0: 1310.0000, 1: 60.0637, 2: 13252.3632}\n" \
+                                "if Attribute 1 > -0.347867256929453:\n" \
+                                "  if Attribute 0 <= -0.010905749904186912:\n" \
+                                "    Leaf = Statistics {0: 966.0000, 1: -1267.0737, 2: 9383.0230}\n" \
+                                "  if Attribute 0 > -0.010905749904186912:\n" \
+                                "    Leaf = Statistics {0: 1724.0000, 1: 1603.8751, 2: 17003.9844}\n" \
+
+                assert expected_info == learner.get_model_description()
+                p1 = True
+            if X[0][0] <= 0 and X[0][1] > 0:
+                y = [np.random.normal(loc=-10, scale=2)]
+            elif X[0][0] > 0 and X[0][1] > 0:
+                y = [np.random.normal(loc=10, scale=2)]
+            elif X[0][0] <= 0 and X[0][1] <= 0:
+                y = [np.random.normal(loc=3, scale=1)]
+            else:
+                y = [np.random.normal(loc=-3, scale=1)]
+        else:
+            if not p2:
+                expected_info = "if Attribute 1 <= -0.347867256929453:\n" \
+                                "  if Attribute 0 <= -0.006772364899497507:\n" \
+                                "    Leaf = Statistics {0: 683.0000, 1: 2035.8518, 2: 6826.7077}\n" \
+                                "  if Attribute 0 > -0.006772364899497507:\n" \
+                                "    Leaf = Statistics {0: 955.0000, 1: -1924.4740, 2: 9547.5316}\n" \
+                                "if Attribute 1 > -0.347867256929453:\n" \
+                                "  Leaf = Statistics {0: 350.0000, 1: 60.4979, 2: 27180.0527}\n"
+
+                assert expected_info == learner.get_model_description()
+                p2 = True
+            if X[0][0] > 0:
+                y = [np.random.normal(loc=20, scale=3)]
+            else:
+                y = [np.random.normal(loc=-20, scale=3)]
 
         learner.partial_fit(X, y)
+
         cnt += 1
 
-        if cnt > change_point:
-            stream = RegressionGenerator(
-                n_samples=3000, n_features=10, n_informative=3, random_state=8
-            )
+    expected_info = "if Attribute 0 <= -0.0008180705425056001:\n" \
+                    "  Leaf = Statistics {0: 851.0000, 1: -17061.1111, 2: 349640.3908}\n" \
+                    "if Attribute 0 > -0.0008180705425056001:\n" \
+                    "  Leaf = Statistics {0: 862.0000, 1: 17124.3350, 2: 349087.9636}\n" \
+
+    assert expected_info == learner.get_model_description()

--- a/tests/trees/test_regression_hoeffding_adaptive_tree.py
+++ b/tests/trees/test_regression_hoeffding_adaptive_tree.py
@@ -216,6 +216,7 @@ def test_hoeffding_adaptive_tree_regressor_alternate_tree():
                 y = [np.random.normal(loc=-3, scale=1)]
         else:
             if not p2:
+                # Subtree turned into leaf (right branch from the root)
                 expected_info = "if Attribute 1 <= -0.347867256929453:\n" \
                                 "  if Attribute 0 <= -0.006772364899497507:\n" \
                                 "    Leaf = Statistics {0: 683.0000, 1: 2035.8518, 2: 6826.7077}\n" \
@@ -235,6 +236,7 @@ def test_hoeffding_adaptive_tree_regressor_alternate_tree():
 
         cnt += 1
 
+    # Root node changed
     expected_info = "if Attribute 0 <= -0.0008180705425056001:\n" \
                     "  Leaf = Statistics {0: 851.0000, 1: -17061.1111, 2: 349640.3908}\n" \
                     "if Attribute 0 > -0.0008180705425056001:\n" \


### PR DESCRIPTION
This PR fixes #154.

Besides, it corrects some typos in the adaptive split nodes where node identifiers were accessed, rather than their content. Incorrect variable naming is also fixed.

Finally, I changed the way Hoeffding Adaptive Tree Regressor monitors its errors using ADWIN. Previously, the errors were calculated using normalized target values and predictions (using the z-score approach, as usually done by the tree regressors). However, as stated in [ADWIN's paper](https://epubs.siam.org/doi/abs/10.1137/1.9781611972771.42), a bounded error metric (w.r.t. its range) is expected. For that reason, I implemented a mechanism to incrementally normalize the monitored error metrics in the `[0,1]` range.

Thanks, @jacobmontiel, for the suggestion.

Changes proposed in this pull request:

* Fix typos and bugs in HAT/HATR.
* Make HATR monitor normalized error metrics with ADWIN.
* Fixes #154.

---

Checklist

- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] Tests are included for new functionality or updated accordingly.
- [x] Travis CI build passes with no errors.
- [x] Test Coverage is maintained (threshold is -0.2%).
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).
