### PR TITLE
[BUG] Reapply lost fixes from #220

### DIFF
--- a/src/skmultiflow/trees/isoup_tree.py
+++ b/src/skmultiflow/trees/isoup_tree.py
@@ -137,8 +137,6 @@ class iSOUPTreeRegressor(HoeffdingTreeRegressor, MultiOutputMixin):
        print('iSOUP Tree Regressor mean absolute error: {}'.format(np.mean(np.abs(y_true - y_pred))))
     """
 
-    _TARGET_MEAN = 'mean'
-    _PERCEPTRON = 'perceptron'
     _ADAPTIVE = 'adaptive'
     # ============================================================
     # == Multi-target Regression Hoeffding Tree implementation ===

--- a/src/skmultiflow/trees/nodes/ada_learning_node.py
+++ b/src/skmultiflow/trees/nodes/ada_learning_node.py
@@ -91,13 +91,15 @@ class AdaLearningNode(LearningNodeNBAdaptive, AdaNode):
             dist = self.get_observed_class_distribution()
         # NB
         elif prediction_option == ht._NAIVE_BAYES:
-            dist = do_naive_bayes_prediction(X, self._observed_class_distribution, self._attribute_observers)
+            dist = do_naive_bayes_prediction(X, self._observed_class_distribution,
+                                             self._attribute_observers)
         # NBAdaptive (default)
         else:
             if self._mc_correct_weight > self._nb_correct_weight:
                 dist = self.get_observed_class_distribution()
             else:
-                dist = do_naive_bayes_prediction(X, self._observed_class_distribution, self._attribute_observers)
+                dist = do_naive_bayes_prediction(X, self._observed_class_distribution,
+                                                 self._attribute_observers)
 
         dist_sum = sum(dist.values())  # sum all values in dictionary
         normalization_factor = dist_sum * self.get_error_estimation() * self.get_error_estimation()

--- a/src/skmultiflow/trees/nodes/ada_learning_node_for_regression.py
+++ b/src/skmultiflow/trees/nodes/ada_learning_node_for_regression.py
@@ -30,6 +30,10 @@ class AdaLearningNodeForRegression(ActiveLearningNodePerceptron, AdaNode):
         self._error_change = False
         self._random_state = check_random_state(random_state)
 
+        # To normalize the observed errors in the [0, 1] range
+        self._min_error = float('Inf')
+        self._max_error = float('-Inf')
+
     # Override AdaNode
     def number_leaves(self):
         return 1
@@ -54,10 +58,8 @@ class AdaLearningNodeForRegression(ActiveLearningNodePerceptron, AdaNode):
 
         super().learn_from_instance(X, y, weight, rhat)
 
-        true_target = y
-        target_prediction = rhat.predict([X])[0]
-
-        normalized_error = rhat.get_normalized_error(target_prediction, true_target)
+        y_pred = rhat.predict([X])[0]
+        normalized_error = self.get_normalized_error(y, y_pred)
 
         if self._estimation_error_weight is None:
             self._estimation_error_weight = ADWIN()
@@ -86,3 +88,17 @@ class AdaLearningNodeForRegression(ActiveLearningNodePerceptron, AdaNode):
         if found_nodes is None:
             found_nodes = []
         found_nodes.append(FoundNode(self, parent, parent_branch))
+
+    def get_normalized_error(self, y, y_pred):
+        abs_error = abs(y - y_pred)
+
+        # Incremental maintenance of the normalization ranges
+        if abs_error < self._min_error:
+            self._min_error = abs_error
+        if abs_error > self._max_error:
+            self._max_error = abs_error
+
+        if self._min_error != self._max_error:
+            return (abs_error - self._min_error) / (self._max_error - self._min_error)
+        else:
+            return 0.0

--- a/src/skmultiflow/trees/nodes/ada_learning_node_for_regression.py
+++ b/src/skmultiflow/trees/nodes/ada_learning_node_for_regression.py
@@ -2,7 +2,6 @@ from skmultiflow.trees.nodes import FoundNode
 from skmultiflow.trees.nodes import ActiveLearningNodePerceptron
 from skmultiflow.trees.nodes import AdaNode
 from skmultiflow.drift_detection.adwin import ADWIN
-from skmultiflow.utils import check_random_state
 
 
 class AdaLearningNodeForRegression(ActiveLearningNodePerceptron, AdaNode):
@@ -24,11 +23,11 @@ class AdaLearningNodeForRegression(ActiveLearningNodePerceptron, AdaNode):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
     """
+
     def __init__(self, initial_class_observations, parent_node, random_state=None):
         super().__init__(initial_class_observations, parent_node, random_state)
         self._estimation_error_weight = ADWIN()
         self._error_change = False
-        self._random_state = check_random_state(random_state)
 
         # To normalize the observed errors in the [0, 1] range
         self._min_error = float('Inf')

--- a/src/skmultiflow/trees/nodes/ada_split_node.py
+++ b/src/skmultiflow/trees/nodes/ada_split_node.py
@@ -92,9 +92,10 @@ class AdaSplitNode(SplitNode, AdaNode):
                 old_error_rate = self.get_error_estimation()
                 alt_error_rate = self._alternate_tree.get_error_estimation()
                 fDelta = .05
-                fN = 1.0 / self._alternate_tree.get_error_width() + 1.0 / (self.get_error_width())
+                fN = 1.0 / self._alternate_tree.get_error_width() + 1.0 / self.get_error_width()
 
-                bound = math.sqrt(2.0 * old_error_rate * (1.0 - old_error_rate) * math.log(2.0 / fDelta) * fN)
+                bound = math.sqrt(2.0 * old_error_rate * (1.0 - old_error_rate) *
+                                  math.log(2.0 / fDelta) * fN)
                 # To check, bound never less than (old_error_rate - alt_error_rate)
                 if bound < (old_error_rate - alt_error_rate):
                     hat._active_leaf_node_cnt -= self.number_leaves()
@@ -139,12 +140,12 @@ class AdaSplitNode(SplitNode, AdaNode):
 
     # Override AdaNode
     def kill_tree_children(self, hat):
-        for child in self._children:
+        for child in self._children.values():
             if child is not None:
                 # Delete alternate tree if it exists
                 if isinstance(child, SplitNode) and child._alternate_tree is not None:
                     child._alternate_tree.kill_tree_children(hat)
-                    self._pruned_alternate_trees += 1
+                    hat.pruned_alternate_trees_cnt += 1
                 # Recursive delete of SplitNodes
                 if isinstance(child, SplitNode):
                     child.kill_tree_children(hat)

--- a/src/skmultiflow/trees/nodes/ada_split_node_for_regression.py
+++ b/src/skmultiflow/trees/nodes/ada_split_node_for_regression.py
@@ -34,7 +34,7 @@ class AdaSplitNodeForRegression(SplitNode, AdaNode):
         self._estimation_error_weight = ADWIN()
         self._alternate_tree = None
         self.error_change = False
-        self._random_state = check_random_state(random_state)
+        self.random_state = check_random_state(random_state)
 
         # To normalize the observed errors in the [0, 1] range
         self._min_error = float('Inf')

--- a/src/skmultiflow/trees/nodes/ada_split_node_for_regression.py
+++ b/src/skmultiflow/trees/nodes/ada_split_node_for_regression.py
@@ -36,6 +36,10 @@ class AdaSplitNodeForRegression(SplitNode, AdaNode):
         self.error_change = False
         self._random_state = check_random_state(random_state)
 
+        # To normalize the observed errors in the [0, 1] range
+        self._min_error = float('Inf')
+        self._max_error = float('-Inf')
+
     # Override AdaNode
     def number_leaves(self):
         num_of_leaves = 0
@@ -63,14 +67,11 @@ class AdaSplitNodeForRegression(SplitNode, AdaNode):
 
     # Override AdaNode
     def learn_from_instance(self, X, y, weight, rhat, parent, parent_branch):
-
-        true_target = y
-
         normalized_error = 0.0
 
         if self.filter_instance_to_leaf(X, parent, parent_branch).node is not None:
-            target_prediction = rhat.predict([X])[0]
-            normalized_error = rhat.get_normalized_error(target_prediction, true_target)
+            y_pred = rhat.predict([X])[0]
+            normalized_error = self.get_normalized_error(y, y_pred)
         if self._estimation_error_weight is None:
             self._estimation_error_weight = ADWIN()
 
@@ -97,7 +98,7 @@ class AdaSplitNodeForRegression(SplitNode, AdaNode):
                 old_error_rate = self.get_error_estimation()
                 alt_error_rate = self._alternate_tree.get_error_estimation()
                 fDelta = .05
-                fN = 1.0 / self._alternate_tree.get_error_width() + 1.0 / (self.get_error_width())
+                fN = 1.0 / self._alternate_tree.get_error_width() + 1.0 / self.get_error_width()
 
                 bound = math.sqrt(2.0 * old_error_rate * (1.0 - old_error_rate) *
                                   math.log(2.0 / fDelta) * fN)
@@ -115,7 +116,7 @@ class AdaSplitNodeForRegression(SplitNode, AdaNode):
                 elif bound < alt_error_rate - old_error_rate:
                     if isinstance(self._alternate_tree, ActiveLearningNode):
                         self._alternate_tree = None
-                    elif isinstance(self._alternate_tree, ActiveLearningNode):
+                    elif isinstance(self._alternate_tree, InactiveLearningNode):
                         self._alternate_tree = None
                     else:
                         self._alternate_tree.kill_tree_children(rhat)
@@ -144,11 +145,11 @@ class AdaSplitNodeForRegression(SplitNode, AdaNode):
 
     # Override AdaNode
     def kill_tree_children(self, rhat):
-        for child in self._children:
+        for child in self._children.values():
             if child is not None:
                 # Delete alternate tree if it exists
                 if isinstance(child, SplitNode) and child._alternate_tree is not None:
-                    self._pruned_alternate_trees += 1
+                    rhat.pruned_alternate_trees_cnt += 1
                 # Recursive delete of SplitNodes
                 if isinstance(child, SplitNode):
                     child.kill_tree_children(rhat)
@@ -190,3 +191,17 @@ class AdaSplitNodeForRegression(SplitNode, AdaNode):
         if self._alternate_tree is not None:
             self._alternate_tree.filter_instance_to_leaves(X, y, weight, self, -999,
                                                            update_splitter_counts, found_nodes)
+
+    def get_normalized_error(self, y, y_pred):
+        abs_error = abs(y - y_pred)
+
+        # Incremental maintenance of the normalization ranges
+        if abs_error < self._min_error:
+            self._min_error = abs_error
+        if abs_error > self._max_error:
+            self._max_error = abs_error
+
+        if self._min_error != self._max_error:
+            return (abs_error - self._min_error) / (self._max_error - self._min_error)
+        else:
+            return 0.0

--- a/src/skmultiflow/trees/nodes/lc_active_learning_node.py
+++ b/src/skmultiflow/trees/nodes/lc_active_learning_node.py
@@ -2,8 +2,6 @@ from skmultiflow.trees.attribute_observer import NumericAttributeClassObserverGa
 from skmultiflow.trees.attribute_observer import NominalAttributeClassObserver
 from skmultiflow.trees.nodes import ActiveLearningNode
 
-NAIVE_BAYES_ADAPTIVE = 'nba'
-
 
 class LCActiveLearningNode(ActiveLearningNode):
     """ Active Learning node for the Label Combination Hoeffding Tree.
@@ -19,7 +17,7 @@ class LCActiveLearningNode(ActiveLearningNode):
 
     def learn_from_instance(self, X, y, weight, ht):
 
-        if not(ht.leaf_prediction == NAIVE_BAYES_ADAPTIVE):
+        if ht.leaf_prediction != ht._NAIVE_BAYES_ADAPTIVE:
             y = ''.join(str(e) for e in y)
             y = int(y, 2)
 

--- a/tests/trees/test_hoeffding_adaptive_tree.py
+++ b/tests/trees/test_hoeffding_adaptive_tree.py
@@ -1,7 +1,8 @@
 import numpy as np
 from array import array
 import os
-from skmultiflow.data import ConceptDriftStream, SEAGenerator, HyperplaneGenerator
+from skmultiflow.data import ConceptDriftStream, SEAGenerator, HyperplaneGenerator, \
+    AGRAWALGenerator
 from skmultiflow.trees import HoeffdingAdaptiveTreeClassifier
 
 
@@ -174,3 +175,52 @@ def test_hoeffding_adaptive_tree_categorical_features(test_path):
                            "  Leaf = Class 3.0 | {3.0: 65.0, 4.0: 55.0}\n"
 
     assert learner.get_model_description() == expected_description
+
+
+def test_hoeffding_adaptive_tree_alternate_tree():
+    stream = AGRAWALGenerator(random_state=7)
+
+    learner = HoeffdingAdaptiveTreeClassifier(random_state=1)
+
+    cnt = 0
+    change_point1 = 1500
+    change_point2 = 2500
+    change_point3 = 4000
+    max_samples = 5000
+
+    while cnt < max_samples:
+        X, y = stream.next_sample()
+        learner.partial_fit(X, y)
+        cnt += 1
+
+        if cnt > change_point1:
+            stream.generate_drift()
+            change_point1 = float('Inf')
+
+            expected_description = "if Attribute 2 <= 63.63636363636363:\n" \
+                                   "  if Attribute 2 <= 39.54545454545455:\n" \
+                                   "    Leaf = Class 0 | {0: 397.5023676194098}\n" \
+                                   "  if Attribute 2 > 39.54545454545455:\n" \
+                                   "    if Attribute 2 <= 58.81818181818181:\n" \
+                                   "      Leaf = Class 1 | {1: 299.8923824199619}\n" \
+                                   "    if Attribute 2 > 58.81818181818181:\n" \
+                                   "      Leaf = Class 0 | {0: 54.0, 1: 20.107617580038095}\n" \
+                                   "if Attribute 2 > 63.63636363636363:\n" \
+                                   "  Leaf = Class 0 | {0: 512.5755895049351}\n"
+            assert expected_description == learner.get_model_description()
+
+        if cnt > change_point2:
+            stream.generate_drift()
+            change_point2 = float('Inf')
+            expected_description = "if Attribute 8 <= 268547.7178694747:\n" \
+                                   "  Leaf = Class 0 | {0: 446.18690518790413, 1: 80.6180778406834}\n" \
+                                   "if Attribute 8 > 268547.7178694747:\n" \
+                                   "  Leaf = Class 1 | {0: 36.8130948120959, 1: 356.38192215931656}\n"
+            assert expected_description == learner.get_model_description()
+
+        if cnt > change_point3:
+            stream.generate_drift()
+            change_point3 = float('Inf')
+
+    expected_description = "Leaf = Class 0 | {0: 1083.0, 1: 2.0}\n"
+    assert expected_description == learner.get_model_description()

--- a/tests/trees/test_hoeffding_adaptive_tree_regressor.py
+++ b/tests/trees/test_hoeffding_adaptive_tree_regressor.py
@@ -168,3 +168,86 @@ def test_regression_hoeffding_adaptive_tree_categorical_features(test_path):
     assert SequenceMatcher(
         None, expected_description, learner.get_model_description()
     ).ratio() > 0.9
+
+
+def test_hoeffding_adaptive_tree_regressor_alternate_tree():
+    learner = HoeffdingAdaptiveTreeRegressor(
+        leaf_prediction='mean', grace_period=1000, random_state=7
+    )
+
+    np.random.seed(8)
+    max_samples = 7000
+    cnt = 0
+
+    p1 = False
+    p2 = False
+
+    while cnt < max_samples:
+        X = [np.random.uniform(low=-1, high=1, size=2)]
+
+        if cnt < 3000:
+            if X[0][0] <= 0 and X[0][1] > 0:
+                y = [np.random.normal(loc=-3, scale=1)]
+            elif X[0][0] > 0 and X[0][1] > 0:
+                y = [np.random.normal(loc=3, scale=1)]
+            elif X[0][0] <= 0 and X[0][1] <= 0:
+                y = [np.random.normal(loc=3, scale=1)]
+            else:
+                y = [np.random.normal(loc=-3, scale=1)]
+        elif cnt < 5000:
+            if not p1:
+                expected_info = "if Attribute 0 <= 0.7308480624289246:\n" \
+                    "  if Attribute 1 <= 0.020068273107131107:\n" \
+                    "    Leaf = Statistics {0: 900.0000, 1: 685.4441, 2: 9052.7232}\n" \
+                    "  if Attribute 1 > 0.020068273107131107:\n" \
+                    "    Leaf = Statistics {0: 1716.0000, 1: -284.7812, 2: 17014.5944}\n" \
+                    "if Attribute 0 > 0.7308480624289246:\n" \
+                    "  Leaf = Statistics {0: 384.0000, 1: -40.5676, 2: 3855.0453}\n"
+
+                assert expected_info == learner.get_model_description()
+                p1 = True
+
+            # Keep almost the same generation function
+            if X[0][0] <= 0 and X[0][1] > 0:
+                y = [np.random.normal(loc=-3, scale=1)]
+            elif X[0][0] > 0 and X[0][1] > 0:
+                y = [np.random.normal(loc=3, scale=1)]
+            elif X[0][0] <= 0 and X[0][1] <= 0:
+                y = [np.random.normal(loc=3, scale=1)]
+            else:
+                y = [np.random.normal(loc=-3, scale=1)]
+
+            # But shift the normal mean in a specific region
+            if X[0][0] <= 0.73:
+                y = [np.random.normal(loc=5, scale=0.1)]
+        elif cnt < 6000:
+            if not p2:
+                # Subtree swapped
+                expected_info = "if Attribute 0 <= 0.7308480624289246:\n" \
+                    "  if Attribute 0 <= 0.7210747610959465:\n" \
+                    "    Leaf = Statistics {0: 1447.0000, 1: 7229.8838, 2: 36138.9433}\n" \
+                    "  if Attribute 0 > 0.7210747610959465:\n" \
+                    "    Leaf = Statistics {0: 8.0000, 1: 30.5281, 2: 183.5354}\n" \
+                    "if Attribute 0 > 0.7308480624289246:\n" \
+                    "  Leaf = Statistics {0: 654.0000, 1: -24.9928, 2: 6519.0335}\n"
+
+                assert expected_info == learner.get_model_description()
+                p2 = True
+
+            # Change how y is generated: only x_1 matters now
+            if X[0][1] > 0:
+                y = [np.random.normal(loc=20, scale=3)]
+            else:
+                y = [np.random.normal(loc=-20, scale=3)]
+
+        learner.partial_fit(X, y)
+
+        cnt += 1
+
+    # Root node changed
+    expected_info = "if Attribute 1 <= -0.00015267114158334927:\n" \
+        "  Leaf = Statistics {0: 904.0000, 1: 1098.6423, 2: 332597.7050}\n" \
+        "if Attribute 1 > -0.00015267114158334927:\n" \
+        "  Leaf = Statistics {0: 905.0000, 1: 17227.8522, 2: 332000.7548}\n"
+
+    assert expected_info == learner.get_model_description()


### PR DESCRIPTION
While syncing my fork with the upstream during the development of #223, I accidentally ended up overwriting (effectively rolling back) some changes implemented in #220. This PR makes sure that those operations are applied.

Changes proposed in this pull request:

* Reapply missing operations from #220

---

### Checklist
#### Implementation
- [x] Implementation is correct (it performs its intended function).
- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] PR description covers ALL the changes performed.
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).

#### Tests
- [x] New functionality is tested.
- [x] Tests are created for the new functionality or existing tests are updated accordingly.
- [x] ALL tests pass with no errors.
- [x] CI/CD pipelines run with no errors.
- [x] Test Coverage is maintained (coverage may drop by no more than 0.2%).
