### PR TITLE
Make EvaluatePrequential and EvaluateHoldout report all processed samples in the output file

### DIFF
--- a/src/skmultiflow/evaluation/evaluate_holdout.py
+++ b/src/skmultiflow/evaluation/evaluate_holdout.py
@@ -285,7 +285,7 @@ class EvaluateHoldout(StreamEvaluator):
                     else:
                         perform_test = (self.global_sample_count - self.test_size) % self.n_wait == 0
 
-                    if perform_test | (self.global_sample_count >= self.max_samples):
+                    if perform_test | (self.global_sample_count >= actual_max_samples):
 
                         if self.dynamic_test_set:
                             print('Separating {} holdout samples.'.format(self.test_size))

--- a/src/skmultiflow/evaluation/evaluate_holdout.py
+++ b/src/skmultiflow/evaluation/evaluate_holdout.py
@@ -71,7 +71,7 @@ class EvaluateHoldout(StreamEvaluator):
         | 'average_mean_squared_error'
         | 'average_mean_absolute_error'
         | 'average_root_mean_square_error'
-        | **Experimental** (no plot generated)
+        | **General purpose** (no plot generated)
         | 'running_time'
         | 'model_size'
 

--- a/src/skmultiflow/evaluation/evaluate_holdout.py
+++ b/src/skmultiflow/evaluation/evaluate_holdout.py
@@ -243,7 +243,7 @@ class EvaluateHoldout(StreamEvaluator):
 
         performance_sampling_cnt = 0
         print('Evaluating...')
-        while ((self.global_sample_count < self.max_samples) & (self._end_time - self._start_time < self.max_time)
+        while ((self.global_sample_count < actual_max_samples) & (self._end_time - self._start_time < self.max_time)
                & (self.stream.has_more_samples())):
             try:
                 X, y = self.stream.next_sample(self.batch_size)

--- a/src/skmultiflow/evaluation/evaluate_prequential.py
+++ b/src/skmultiflow/evaluation/evaluate_prequential.py
@@ -355,7 +355,7 @@ class EvaluatePrequential(StreamEvaluator):
                             self.running_time_measurements[i].update_time_measurements(self.batch_size)
 
                     if ((self.global_sample_count % self.n_wait) == 0 or
-                            (self.global_sample_count >= self.max_samples) or
+                            (self.global_sample_count >= actual_max_samples) or
                             (self.global_sample_count / self.n_wait > update_count + 1)):
                         if prediction is not None:
                             self._update_metrics()

--- a/src/skmultiflow/evaluation/evaluate_prequential.py
+++ b/src/skmultiflow/evaluation/evaluate_prequential.py
@@ -69,7 +69,7 @@ class EvaluatePrequential(StreamEvaluator):
         | 'average_mean_squared_error'
         | 'average_mean_absolute_error'
         | 'average_root_mean_square_error'
-        | **Experimental** (no plot generated)
+        | **General purpose** (no plot generated)
         | 'running_time'
         | 'model_size'
 


### PR DESCRIPTION
This PR updates the default behavior of `EvaluatePrequential` when reporting the last measurements and writing the output file. The current implementation updates metrics until the last multiple of `n_wait` which might be less than the user-defined `max_samples`, provided that there are enough samples in the stream. For example, if `max_samples=2500`and `n_wait=200` then the last metrics update is performed at `sample_count=2400` 

#### Expected behavior

Evaluators (prequential and hold out) **must** include measurements for up to `max_samples` regardless if `n_wait` has been reached at the end of the evaluation. In the example above, a final metrics update must be performed for the remaining `100` samples in the stream, to get the final metrics at `sample_count=2500`.

---

### Checklist
#### Implementation
- [x] Implementation is correct (it performs its intended function).
- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] PR description covers ALL the changes performed.
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).

#### Tests
- [x] New functionality is tested.
- [x] Tests are created for the new functionality or existing tests are updated accordingly.
- [x] ALL tests pass with no errors.
- [x] CI/CD pipelines run with no errors.
- [x] Test Coverage is maintained (coverage may drop by no more than 0.2%).
