### PR TITLE
Use Numpy infix notation.

### DIFF
--- a/src/skmultiflow/meta/online_smote_bagging.py
+++ b/src/skmultiflow/meta/online_smote_bagging.py
@@ -262,7 +262,7 @@ class OnlineSMOTEBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimator
                 k = len(neighbors)
             i = self._random_state.randint(0, k)
             gamma = self._random_state.rand()
-            x_smote = np.add(x, np.multiply(gamma, np.subtract(x, self.pos_samples[neighbors[i]])))
+            x_smote = x + gamma * (x - self.pos_samples[neighbors[i]])
             return x_smote
         return self.pos_samples[-1]
 

--- a/src/skmultiflow/trees/hoeffding_adaptive_tree_regressor.py
+++ b/src/skmultiflow/trees/hoeffding_adaptive_tree_regressor.py
@@ -198,7 +198,7 @@ class HoeffdingAdaptiveTreeRegressor(HoeffdingTreeRegressor):
 
         try:
             self.sum_of_attribute_values += weight * X
-            self.sum_of_attribute_squares = weight * X * X
+            self.sum_of_attribute_squares += weight * X * X
         except ValueError:
             
             self.sum_of_attribute_values = weight * X

--- a/src/skmultiflow/trees/hoeffding_adaptive_tree_regressor.py
+++ b/src/skmultiflow/trees/hoeffding_adaptive_tree_regressor.py
@@ -197,13 +197,12 @@ class HoeffdingAdaptiveTreeRegressor(HoeffdingTreeRegressor):
         self.sum_of_squares += weight * y * y
 
         try:
-            self.sum_of_attribute_values = np.add(self.sum_of_attribute_values,
-                                                  np.multiply(weight, X))
-            self.sum_of_attribute_squares = np.add(self.sum_of_attribute_squares,
-                                                   np.multiply(weight, np.power(X, 2)))
+            self.sum_of_attribute_values += weight * X
+            self.sum_of_attribute_squares = weight * X * X
         except ValueError:
-            self.sum_of_attribute_values = np.multiply(weight, X)
-            self.sum_of_attribute_squares = np.multiply(weight, np.power(X, 2))
+            
+            self.sum_of_attribute_values = weight * X
+            self.sum_of_attribute_squares = weight * X * X
 
         if self._tree_root is None:
             self._tree_root = self._new_learning_node()

--- a/src/skmultiflow/trees/hoeffding_tree_regressor.py
+++ b/src/skmultiflow/trees/hoeffding_tree_regressor.py
@@ -381,14 +381,11 @@ class HoeffdingTreeRegressor(RegressorMixin, HoeffdingTreeClassifier):
         self.sum_of_squares += sample_weight * y * y
 
         try:
-            self.sum_of_attribute_values = np.add(self.sum_of_attribute_values,
-                                                  np.multiply(sample_weight, X))
-            self.sum_of_attribute_squares = np.add(
-                self.sum_of_attribute_squares, np.multiply(sample_weight, np.power(X, 2))
-            )
+            self.sum_of_attribute_values += sample_weight * X
+            self.sum_of_attribute_squares += sample_weight * X * X
         except ValueError:
-            self.sum_of_attribute_values = np.multiply(sample_weight, X)
-            self.sum_of_attribute_squares = np.multiply(sample_weight, np.power(X, 2))
+            self.sum_of_attribute_values = sample_weight * X
+            self.sum_of_attribute_squares = sample_weight * X * X
 
         if self._tree_root is None:
             self._tree_root = self._new_learning_node()

--- a/src/skmultiflow/trees/hoeffding_tree_regressor.py
+++ b/src/skmultiflow/trees/hoeffding_tree_regressor.py
@@ -458,7 +458,7 @@ class HoeffdingTreeRegressor(RegressorMixin, HoeffdingTreeClassifier):
                             predictions.append(0.0)
                             continue
                         normalized_sample = self.normalize_sample(X[i])
-                        normalized_prediction = np.dot(perceptron_weights, normalized_sample)
+                        normalized_prediction = perceptron_weights.dot(normalized_sample)
                         # De-normalize prediction
                         mean = self.sum_of_values / self.samples_seen
                         sd = compute_sd(self.sum_of_squares, self.sum_of_values, self.samples_seen)


### PR DESCRIPTION
Changes proposed in this pull request:
* Let numpy infer the infix notation instead of using np.ufunc().

---

### Checklist
#### Implementation
- [x] Implementation is correct (it performs its intended function).
- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] PR description covers ALL the changes performed.
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).

#### Tests
- [x] ALL tests pass with no errors.
- [x] CI/CD pipelines run with no errors.
- [x] Test Coverage is maintained (coverage may drop by no more than 0.2%).

---
This is a fresh & up-to-date version of #181 