### PR TITLE
Update default value for alpha in ConceptDriftStream

### DIFF
--- a/src/skmultiflow/data/concept_drift_stream.py
+++ b/src/skmultiflow/data/concept_drift_stream.py
@@ -1,3 +1,5 @@
+import warnings
+
 import numpy as np
 from skmultiflow.data.base_stream import Stream
 from skmultiflow.utils import check_random_state
@@ -80,6 +82,10 @@ class ConceptDriftStream(Stream):
         self.random_state = random_state
         self._random_state = None   # This is the actual random_state object used internally
         self.alpha = alpha
+        if self.alpha == 0:
+            warnings.warn("Default value for 'alpha' has changed from 0 to None. 'alpha=0' will "
+                          "throw an error from v0.7.0", category=FutureWarning)
+            self.alpha = None
         if self.alpha is not None:
             if 0 < self.alpha <= 90.0:
                 w = int(1 / np.tan(self.alpha * np.pi / 180))

--- a/src/skmultiflow/data/concept_drift_stream.py
+++ b/src/skmultiflow/data/concept_drift_stream.py
@@ -34,9 +34,10 @@ class ConceptDriftStream(Stream):
         If None, the random number generator is the RandomState instance used
         by `np.random`.
 
-    alpha: float (optional, default: 0.0)
-        Angle of change to estimate the width of concept drift change. If set will override
-        the width parameter. Valid values are in the range (0.0, 90.0].
+    alpha: float (optional, default: None)
+        Angle of change to estimate the width of concept drift change. If set will override the width parameter.
+        Valid values are in the range (0.0, 90.0].
+        If alpha is None, this parameter will be ignored.
 
     position: int (default: 5000)
         Central position of concept drift change.
@@ -60,7 +61,7 @@ class ConceptDriftStream(Stream):
                  position=5000,
                  width=1000,
                  random_state=None,
-                 alpha=0.0):
+                 alpha=None):
         super(ConceptDriftStream, self).__init__()
 
         self.n_samples = stream.n_samples
@@ -77,9 +78,9 @@ class ConceptDriftStream(Stream):
         self.name = 'Drifting' + stream.name
 
         self.random_state = random_state
-        self._random_state = None  # This is the actual random_state object used internally
+        self._random_state = None   # This is the actual random_state object used internally
         self.alpha = alpha
-        if self.alpha != 0.0:
+        if self.alpha is not None:
             if 0 < self.alpha <= 90.0:
                 w = int(1 / np.tan(self.alpha * np.pi / 180))
                 self.width = w if w > 0 else 1

--- a/src/skmultiflow/data/concept_drift_stream.py
+++ b/src/skmultiflow/data/concept_drift_stream.py
@@ -37,8 +37,8 @@ class ConceptDriftStream(Stream):
         by `np.random`.
 
     alpha: float (optional, default: None)
-        Angle of change to estimate the width of concept drift change. If set will override the width parameter.
-        Valid values are in the range (0.0, 90.0].
+        Angle of change to estimate the width of concept drift change.
+        If set will override the width parameter. Valid values are in the range (0.0, 90.0].
         If alpha is None, this parameter will be ignored.
 
     position: int (default: 5000)

--- a/tests/data/test_concept_drift_stream.py
+++ b/tests/data/test_concept_drift_stream.py
@@ -1,5 +1,7 @@
 import os
 import numpy as np
+import pytest
+
 from skmultiflow.data import ConceptDriftStream
 
 
@@ -81,3 +83,10 @@ def test_concept_drift_stream_with_alpha(test_path):
                     "                                           perturbation=0.0, random_state=112),\n" \
                     "                   width=5729)"
     assert stream.get_info() == expected_info
+
+    with pytest.warns(FutureWarning) as actual_warning:
+        ConceptDriftStream(alpha=0, random_state=1, position=20)
+
+    assert actual_warning[0].message.args[0] == "Default value for 'alpha' has changed from 0 " \
+                                            "to None. 'alpha=0' will throw an error from v0.7.0"
+

--- a/tests/data/test_concept_drift_stream.py
+++ b/tests/data/test_concept_drift_stream.py
@@ -53,7 +53,7 @@ def test_concept_drift_stream(test_path):
 
     assert 'stream' == stream._estimator_type
 
-    expected_info = "ConceptDriftStream(alpha=0.0,\n" \
+    expected_info = "ConceptDriftStream(alpha=None,\n" \
                     "                   drift_stream=AGRAWALGenerator(balance_classes=False,\n" \
                     "                                                 classification_function=2,\n" \
                     "                                                 perturbation=0.0,\n" \

--- a/tests/data/test_concept_drift_stream.py
+++ b/tests/data/test_concept_drift_stream.py
@@ -8,7 +8,8 @@ def test_concept_drift_stream(test_path):
 
     assert stream.n_remaining_samples() == -1
 
-    expected_names = ["salary", "commission", "age", "elevel", "car", "zipcode", "hvalue", "hyears", "loan"]
+    expected_names = ["salary", "commission", "age", "elevel", "car", "zipcode", "hvalue",
+                      "hyears", "loan"]
     assert stream.feature_names == expected_names
 
     expected_targets = [0, 1]
@@ -63,4 +64,20 @@ def test_concept_drift_stream(test_path):
                     "                                           classification_function=0,\n" \
                     "                                           perturbation=0.0, random_state=112),\n" \
                     "                   width=5)"
+    assert stream.get_info() == expected_info
+
+
+def test_concept_drift_stream_with_alpha(test_path):
+    stream = ConceptDriftStream(alpha=0.01, random_state=1, position=20)
+
+    expected_info = "ConceptDriftStream(alpha=0.01,\n" \
+                    "                   drift_stream=AGRAWALGenerator(balance_classes=False,\n" \
+                    "                                                 classification_function=2,\n" \
+                    "                                                 perturbation=0.0,\n" \
+                    "                                                 random_state=112),\n" \
+                    "                   position=20, random_state=1,\n" \
+                    "                   stream=AGRAWALGenerator(balance_classes=False,\n" \
+                    "                                           classification_function=0,\n" \
+                    "                                           perturbation=0.0, random_state=112),\n" \
+                    "                   width=5729)"
     assert stream.get_info() == expected_info


### PR DESCRIPTION
<!-- 
Thank you for contributing with a PR!

Please fill the description of change(s) and/or indicate if it fixes an open issue (optional).

To ease the merge process please review the attached checklist.
-->

Changes proposed in this pull request:

Use `None` as the default value instead of `0.0`. Because the old default value is confusing with the range of alpha which is `(0.0, 90.0]`.



### Checklist
#### Implementation
- [x] Implementation is correct (it performs its intended function).
- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] PR description covers ALL the changes performed.
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).

#### Tests
- [x] New functionality is tested.
- [x] Tests are created for the new functionality or existing tests are updated accordingly.
- [x] ALL tests pass with no errors.
- [x] CI/CD pipelines run with no errors.
- [x] Test Coverage is maintained (coverage may drop by no more than 0.2%).
