### PR TITLE
Fix bug in the LeveragingBaggingClassifier and NaiveBayes

### DIFF
--- a/src/skmultiflow/bayes/naive_bayes.py
+++ b/src/skmultiflow/bayes/naive_bayes.py
@@ -164,12 +164,11 @@ class NaiveBayes(BaseSKMObject, ClassifierMixin):
 
         """
         predictions = deque()
+        r, _ = get_dimensions(X)
         if self._observed_class_distribution == {}:
             # Model is empty, all classes equal, default to zero
-            r, _ = get_dimensions(X)
-            return np.zeros(r)
+            return np.zeros((r, 1))
         else:
-            r, _ = get_dimensions(X)
             for i in range(r):
                 votes = do_naive_bayes_prediction(X[i], self._observed_class_distribution, self._attribute_observers)
                 sum_values = sum(votes.values())

--- a/src/skmultiflow/meta/leverage_bagging.py
+++ b/src/skmultiflow/meta/leverage_bagging.py
@@ -171,9 +171,7 @@ class LeveragingBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorM
             self.base_estimator.reset()
         self.actual_n_estimators = self.n_estimators
         self.ensemble = [cp.deepcopy(self.base_estimator) for _ in range(self.actual_n_estimators)]
-        self.adwin_ensemble = []
-        for i in range(self.actual_n_estimators):
-            self.adwin_ensemble.append(ADWIN(self.delta))
+        self.adwin_ensemble = [ADWIN(self.delta) for _ in range(self.actual_n_estimators)]
         self._random_state = check_random_state(self.random_state)
         self.n_detected_changes = 0
         self.classes = None
@@ -325,14 +323,6 @@ class LeveragingBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorM
                 condition = ((n_ones - n_zeros) * (n_ones - n_zeros) >
                              (self.actual_n_estimators % 2))
         self.init_matrix_codes = False
-
-    def __adjust_ensemble_size(self):
-        if len(self.classes) != len(self.ensemble):
-            if len(self.classes) > len(self.ensemble):
-                for i in range(len(self.ensemble), len(self.classes)):
-                    self.ensemble.append(cp.deepcopy(self.base_estimator))
-                    self.adwin_ensemble.append(ADWIN(self.delta))
-                    self.actual_n_estimators += 1
 
     def predict(self, X):
         """ Predict classes for the passed data.

--- a/src/skmultiflow/meta/leverage_bagging.py
+++ b/src/skmultiflow/meta/leverage_bagging.py
@@ -244,7 +244,8 @@ class LeveragingBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorM
                     k = 1.0
                 elif pred[0] != y:
                     k = 1.0
-                elif self._random_state.rand() < (error / (1.0 - error)):
+                elif (error != 1.0 and
+                      self._random_state.rand() < (error / (1.0 - error))):
                     k = 1.0
                 else:
                     k = 0.0
@@ -281,17 +282,14 @@ class LeveragingBaggingClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorM
                     self.ensemble[i].partial_fit(X=np.asarray([X]), y=np.asarray([y_coded]),
                                                  classes=classes)
 
-            try:
-                pred = self.ensemble[i].predict(np.asarray([X]))
-                if pred is not None:
-                    add = 1 if (pred[0] == y_coded) else 0
-                    error = self.adwin_ensemble[i].estimation
-                    self.adwin_ensemble[i].add_element(add)
-                    if self.adwin_ensemble[i].detected_change():
-                        if self.adwin_ensemble[i].estimation > error:
-                            change_detected = True
-            except ValueError:
-                change_detected = False
+            pred = self.ensemble[i].predict(np.asarray([X]))
+            if pred is not None:
+                add = 0 if (pred[0] == y_coded) else 1
+                error = self.adwin_ensemble[i].estimation
+                self.adwin_ensemble[i].add_element(add)
+                if self.adwin_ensemble[i].detected_change():
+                    if self.adwin_ensemble[i].estimation > error:
+                        change_detected = True
 
         if change_detected:
             self.n_detected_changes += 1

--- a/tests/meta/test_leverage_bagging.py
+++ b/tests/meta/test_leverage_bagging.py
@@ -199,7 +199,8 @@ def test_leverage_bagging_coverage():
 
     # Reset ensemble
     estimator.reset()
-    assert estimator.ensemble
+    assert estimator.classes is None
+
 
 def run_prequential_supervised(stream, learner, max_samples, n_wait, y_expected=None):
     stream.restart()

--- a/tests/meta/test_leverage_bagging.py
+++ b/tests/meta/test_leverage_bagging.py
@@ -74,8 +74,8 @@ def test_leverage_bagging_me():
                                           random_state=112,
                                           leverage_algorithm='leveraging_bag_me')
 
-    y_expected = np.asarray([0, 0, 0, 0, 1, 0, 1, 0, 1, 0,
-                             1, 0, 0, 0, 1, 0, 1, 1, 1, 1,
+    y_expected = np.asarray([0, 0, 1, 0, 1, 0, 1, 0, 1, 0,
+                             1, 1, 1, 0, 1, 1, 1, 1, 1, 1,
                              1, 1, 1, 1, 0, 1, 0, 1, 1, 0,
                              0, 0, 1, 1, 1, 0, 1, 1, 0, 0,
                              1, 0, 0, 1, 0, 0, 0, 1, 1, 0], dtype=np.int)

--- a/tests/meta/test_leverage_bagging.py
+++ b/tests/meta/test_leverage_bagging.py
@@ -1,9 +1,10 @@
 from skmultiflow.meta import LeveragingBaggingClassifier
 from skmultiflow.lazy import KNNClassifier
-from skmultiflow.data import SEAGenerator, RandomTreeGenerator
+from skmultiflow.data import SEAGenerator, RandomTreeGenerator, ConceptDriftStream
 from skmultiflow.bayes import NaiveBayes
 
 import numpy as np
+import pytest
 
 
 def test_leverage_bagging():
@@ -61,24 +62,22 @@ def test_leverage_bagging():
 
 
 def test_leverage_bagging_me():
-    stream = SEAGenerator(classification_function=1,
-                          noise_percentage=0.067,
-                          random_state=112)
-    knn = KNNClassifier(n_neighbors=8,
-                        leaf_size=40,
-                        max_window_size=2000)
+    stream = ConceptDriftStream(position=500,
+                                width=100,
+                                random_state=112)
+    nb = NaiveBayes()
 
     # leveraging_bag_me
-    learner = LeveragingBaggingClassifier(base_estimator=knn,
-                                          n_estimators=3,
+    learner = LeveragingBaggingClassifier(base_estimator=nb,
+                                          n_estimators=5,
                                           random_state=112,
                                           leverage_algorithm='leveraging_bag_me')
 
-    y_expected = np.asarray([0, 0, 1, 0, 1, 0, 1, 0, 1, 0,
-                             1, 1, 1, 0, 1, 1, 1, 1, 1, 1,
-                             1, 1, 1, 1, 0, 1, 0, 1, 1, 0,
-                             0, 0, 1, 1, 1, 0, 1, 1, 0, 0,
-                             1, 0, 0, 1, 0, 0, 0, 1, 1, 0], dtype=np.int)
+    y_expected = np.asarray([0, 0, 0, 1, 0, 1, 0, 0, 1, 0,
+                             0, 0, 0, 1, 0, 0, 1, 1, 0, 0,
+                             1, 0, 0, 0, 1, 1, 0, 1, 0, 1,
+                             0, 0, 0, 1, 1, 0, 1, 1, 1, 0,
+                             1, 0, 1, 0, 0, 1, 1, 0, 1, 0], dtype=np.int)
 
     run_prequential_supervised(stream, learner, max_samples=2000, n_wait=40,
                                y_expected=y_expected)
@@ -176,6 +175,31 @@ def test_leverage_bagging_code_matrix():
     run_prequential_supervised(stream, learner, max_samples=2000, n_wait=40,
                                y_expected=y_expected)
 
+
+def test_leverage_bagging_coverage():
+    # Invalid leverage_algorithm
+    with pytest.raises(ValueError):
+        LeveragingBaggingClassifier(leverage_algorithm='invalid')
+
+    estimator = LeveragingBaggingClassifier(random_state=4321)
+    stream = SEAGenerator(random_state=4321)
+    X, y = stream.next_sample()
+
+    # classes not passed in partial_fit
+    with pytest.raises(ValueError):
+        estimator.partial_fit(X, y, classes=None)
+    estimator.partial_fit(X, y, classes=stream.target_values)
+    # different observed classes
+    with pytest.raises(ValueError):
+        estimator.partial_fit(X, y, classes=stream.target_values + [-1])
+    # Invalid leverage_algorithm, changed after initialization
+    with pytest.raises(RuntimeError):
+        estimator.leverage_algorithm = 'invalid'
+        estimator.partial_fit(X, y, classes=stream.target_values)
+
+    # Reset ensemble
+    estimator.reset()
+    assert estimator.ensemble
 
 def run_prequential_supervised(stream, learner, max_samples, n_wait, y_expected=None):
     stream.restart()


### PR DESCRIPTION
Changes proposed in this pull request:

- Correct the value passed to ADWIN in `LeveragingBaggingClassifier` to monitor performance, previously this value was inverted.
- Add protection against division by zero.
- Update test cases and improve coverage.
- Remove dead code in `LeveragingBaggingClassifier`.
- Replace `adwin_ensemble` creation with list comprehension.
- Remove obsolete `try` in `LeveragingBaggingClassifier ` from the time when not all models were defaulting to prediction=[0] when empty. This is no longer necessary as now all classifiers return a valid value.
- Make the output of `predict_proba` in `NaiveBayes` 2D when the model is empty.
- Fixes #240 

---

### Checklist
#### Implementation
- [x] Implementation is correct (it performs its intended function).
- [x] Code complies with PEP-8 and is consistent with the framework.
- [x] Code is properly documented.
- [x] PR description covers ALL the changes performed.
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).

#### Tests
- [ ] New functionality is tested.
- [x] Tests are created for the new functionality or existing tests are updated accordingly.
- [x] ALL tests pass with no errors.
- [x] CI/CD pipelines run with no errors.
- [x] Test Coverage is maintained (coverage may drop by no more than 0.2%).
