### PR TITLE
Fix PEP8 problems

### DIFF
--- a/src/skmultiflow/core/base.py
+++ b/src/skmultiflow/core/base.py
@@ -130,7 +130,7 @@ def _pprint(params, offset=0, printer=repr):
     np.set_printoptions(**options)
     lines = ''.join(params_list)
     # Strip trailing space to avoid nightmare in doctests
-    lines = '\n'.join(l.rstrip(' ') for l in lines.split('\n'))
+    lines = '\n'.join(line.rstrip(' ') for line in lines.split('\n'))
     return lines
 
 

--- a/src/skmultiflow/data/data_stream.py
+++ b/src/skmultiflow/data/data_stream.py
@@ -403,7 +403,7 @@ class DataStream(Stream):
         if self.task_type == self._CLASSIFICATION:
             return "{}{} target(s), {} classes".format(name, self.n_targets, self.n_classes)
         elif self.task_type == self._REGRESSION:
-            return "{} target(s)".format(name, self.n_targets)
+            return "{}{} target(s)".format(name, self.n_targets)
 
     def _get_target_values(self):
         if self.task_type == 'classification':

--- a/tests/data/test_data_stream.py
+++ b/tests/data/test_data_stream.py
@@ -121,6 +121,15 @@ def test_data_stream_X_y(test_path):
 
     assert stream.n_features == X.shape[1]
 
+    # Ensure that the regression case is also covered
+    y = raw_data.iloc[:, -1:]
+    X = raw_data.iloc[:, :-1]
+    y = y.astype('float64')
+    stream = DataStream(X, y, name='Test')
+
+    assert stream.task_type == 'regression'
+    assert stream.get_data_info() == 'Test: 1 target(s)'
+
 
 def test_check_data():
     # Test if data contains non-numeric values


### PR DESCRIPTION
Addresses two minor problems that are making fail the recently added linting check:

Changes proposed in this pull request:

* Remove inadvisable usage of 'l' as variable name (E741) in `core.base`
* Fix missing string.format parameter (F523) in `data.DataStream`

---

### Checklist
#### Implementation
- [x] Implementation is correct (it performs its intended function).
- [x] Code is consistent with the framework.
- [ ] Code is properly documented.
- [x] PR description covers ALL the changes performed.
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).

#### Tests
- [ ] New functionality is tested.
- [ ] Tests are created for the new functionality or existing tests are updated accordingly.
- [x] ALL tests pass with no errors.
- [x] CI/CD pipelines run with no errors.
- [x] Test Coverage is maintained (coverage may drop by no more than 0.2%).
