### PR TITLE
Fix CI/CD pipeline and streamline sklearn-dependent tests

### DIFF
--- a/tests/meta/test_batch_incremental.py
+++ b/tests/meta/test_batch_incremental.py
@@ -2,7 +2,11 @@ from skmultiflow.data import RandomTreeGenerator
 from skmultiflow.meta.batch_incremental import BatchIncrementalClassifier
 
 from sklearn.tree import DecisionTreeClassifier
+from sklearn import set_config
 import numpy as np
+# Force sklearn to show only the parameters whose default value have been changed when
+# printing an estimator (backwards compatibility with versions prior to sklearn==0.23)
+set_config(print_changed_only=True)
 
 
 def test_batch_incremental():
@@ -49,10 +53,7 @@ def test_batch_incremental():
 
     assert type(learner.predict(X)) == np.ndarray
 
-    expected_info = "BatchIncrementalClassifier(base_estimator=DecisionTreeClassifier(ccp_alpha=0.0, " \
-                    "class_weight=None, criterion='gini', max_depth=None, max_features=None, max_leaf_nodes=None, " \
-                    "min_impurity_decrease=0.0, min_impurity_split=None, min_samples_leaf=1, min_samples_split=2, " \
-                    "min_weight_fraction_leaf=0.0, presort='deprecated', random_state=112, splitter='best'), " \
-                    "n_estimators=10, window_size=100)"
+    expected_info = "BatchIncrementalClassifier(base_estimator=DecisionTreeClassifier("\
+                    "random_state=112), n_estimators=10, window_size=100)"
     info = " ".join([line.strip() for line in learner.get_info().split()])
     assert info == expected_info

--- a/tests/meta/test_classifier_chains.py
+++ b/tests/meta/test_classifier_chains.py
@@ -2,11 +2,16 @@ import pytest
 
 from sklearn.linear_model import SGDClassifier
 from sklearn import __version__ as sklearn_version
+from sklearn import set_config
 
 from skmultiflow.data import MultilabelGenerator, make_logical
-from skmultiflow.meta import ClassifierChain, MonteCarloClassifierChain, ProbabilisticClassifierChain
+from skmultiflow.meta import ClassifierChain, MonteCarloClassifierChain, \
+    ProbabilisticClassifierChain
 
 import numpy as np
+# Force sklearn to show only the parameters whose default value have been changed when
+# printing an estimator (backwards compatibility with versions prior to sklearn==0.23)
+set_config(print_changed_only=True)
 
 
 @pytest.mark.filterwarnings('ignore::UserWarning')
@@ -14,7 +19,7 @@ def test_classifier_chains():
     seed = 112
     stream = MultilabelGenerator(random_state=seed, n_targets=3, n_samples=5150)
 
-    estimator = SGDClassifier(random_state=seed, tol=1e-3, max_iter=10)
+    estimator = SGDClassifier(random_state=seed, max_iter=10)
     learner = ClassifierChain(base_estimator=estimator, random_state=seed)
     X, y = stream.next_sample(150)
     learner.partial_fit(X, y)
@@ -39,52 +44,52 @@ def test_classifier_chains():
         cnt += 1
 
     if not sklearn_version.startswith("0.21"):
-        expected_predictions = [[0., 0., 1.], [0., 0., 0.], [1., 0., 1.], [1., 0., 1.], [0., 0., 1.], [1., 0., 0.],
-                                [1., 0., 1.], [1., 0., 1.], [0., 0., 1.], [0., 0., 0.], [1., 0., 1.], [0., 0., 1.],
-                                [0., 0., 1.], [0., 0., 1.], [0., 0., 1.], [0., 0., 1.], [1., 0., 1.], [0., 0., 0.],
-                                [1., 0., 1.], [0., 0., 0.], [0., 1., 1.], [0., 1., 1.], [0., 0., 1.], [0., 1., 1.],
-                                [0., 1., 1.], [0., 1., 1.], [0., 1., 0.], [0., 1., 0.], [1., 1., 1.], [0., 1., 0.],
-                                [0., 1., 1.], [1., 0., 1.], [0., 1., 1.], [0., 0., 0.], [0., 0., 0.], [1., 0., 0.],
-                                [1., 1., 1.], [0., 1., 1.], [0., 0., 0.], [1., 0., 1.], [0., 0., 1.], [0., 0., 0.],
-                                [0., 0., 0.], [0., 0., 1.], [0., 1., 0.], [0., 0., 0.], [1., 1., 1.], [0., 0., 0.],
+        expected_predictions = [[0., 0., 1.], [0., 0., 0.], [1., 0., 1.], [1., 0., 1.],
+                                [0., 0., 1.], [1., 0., 0.], [1., 0., 1.], [1., 0., 1.],
+                                [0., 0., 1.], [0., 0., 0.], [1., 0., 1.], [0., 0., 1.],
+                                [0., 0., 1.], [0., 0., 1.], [0., 0., 1.], [0., 0., 1.],
+                                [1., 0., 1.], [0., 0., 0.], [1., 0., 1.], [0., 0., 0.],
+                                [0., 1., 1.], [0., 1., 1.], [0., 0., 1.], [0., 1., 1.],
+                                [0., 1., 1.], [0., 1., 1.], [0., 1., 0.], [0., 1., 0.],
+                                [1., 1., 1.], [0., 1., 0.], [0., 1., 1.], [1., 0., 1.],
+                                [0., 1., 1.], [0., 0., 0.], [0., 0., 0.], [1., 0., 0.],
+                                [1., 1., 1.], [0., 1., 1.], [0., 0., 0.], [1., 0., 1.],
+                                [0., 0., 1.], [0., 0., 0.], [0., 0., 0.], [0., 0., 1.],
+                                [0., 1., 0.], [0., 0., 0.], [1., 1., 1.], [0., 0., 0.],
                                 [1., 1., 1.]]
         assert np.alltrue(np.array_equal(predictions, expected_predictions))
 
         expected_correct_predictions = 26
         assert correct_predictions == expected_correct_predictions
 
-        expected_info = "ClassifierChain(base_estimator=SGDClassifier(alpha=0.0001, average=False, " \
-                        "class_weight=None, early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True, " \
-                        "l1_ratio=0.15, learning_rate='optimal', loss='hinge', max_iter=10, n_iter_no_change=5, " \
-                        "n_jobs=None, penalty='l2', power_t=0.5, random_state=112, shuffle=True, tol=0.001, " \
-                        "validation_fraction=0.1, verbose=0, warm_start=False), order=None, random_state=112)"
+        expected_info = "ClassifierChain(base_estimator=SGDClassifier(max_iter=10, " \
+                        "random_state=112), order=None, random_state=112)"
         info = " ".join([line.strip() for line in learner.get_info().split()])
         assert info == expected_info
 
     else:
-        expected_predictions = [[0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [1.0, 0.0, 1.0], [1.0, 0.0, 1.0], [0.0, 0.0, 1.0],
-                                [1.0, 0.0, 0.0], [1.0, 0.0, 1.0], [1.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 0.0],
-                                [1.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0],
-                                [0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [0.0, 0.0, 0.0], [1.0, 0.0, 1.0], [0.0, 0.0, 0.0],
-                                [0.0, 1.0, 1.0], [0.0, 1.0, 1.0], [0.0, 0.0, 1.0], [0.0, 1.0, 1.0], [0.0, 1.0, 1.0],
-                                [0.0, 1.0, 1.0], [0.0, 1.0, 0.0], [0.0, 1.0, 0.0], [1.0, 1.0, 1.0], [0.0, 1.0, 0.0],
-                                [0.0, 1.0, 1.0], [1.0, 0.0, 1.0], [0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0],
-                                [1.0, 0.0, 0.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [1.0, 0.0, 1.0],
-                                [0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0],
-                                [0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [0.0, 0.0, 0.0], [1.0, 1.0, 1.0]]
+        expected_predictions = [[0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [1.0, 0.0, 1.0], [1.0, 0.0, 1.0],
+                                [0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [1.0, 0.0, 1.0], [1.0, 0.0, 1.0],
+                                [0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [1.0, 0.0, 1.0], [0.0, 0.0, 1.0],
+                                [0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0],
+                                [1.0, 0.0, 1.0], [0.0, 0.0, 0.0], [1.0, 0.0, 1.0], [0.0, 0.0, 0.0],
+                                [0.0, 1.0, 1.0], [0.0, 1.0, 1.0], [0.0, 0.0, 1.0], [0.0, 1.0, 1.0],
+                                [0.0, 1.0, 1.0], [0.0, 1.0, 1.0], [0.0, 1.0, 0.0], [0.0, 1.0, 0.0],
+                                [1.0, 1.0, 1.0], [0.0, 1.0, 0.0], [0.0, 1.0, 1.0], [1.0, 0.0, 1.0],
+                                [0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [1.0, 0.0, 0.0],
+                                [1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [0.0, 0.0, 0.0], [1.0, 0.0, 1.0],
+                                [0.0, 0.0, 1.0], [0.0, 0.0, 0.0], [0.0, 0.0, 0.0], [0.0, 0.0, 1.0],
+                                [0.0, 1.0, 0.0], [0.0, 0.0, 0.0], [1.0, 1.0, 1.0], [0.0, 0.0, 0.0],
+                                [1.0, 1.0, 1.0]]
         assert np.alltrue(np.array_equal(predictions, expected_predictions))
 
         expected_correct_predictions = 26
         assert correct_predictions == expected_correct_predictions
 
-        expected_info = "ClassifierChain(base_estimator=SGDClassifier(alpha=0.0001, average=False, class_weight=None,\n" \
-                        "              early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True,\n" \
-                        "              l1_ratio=0.15, learning_rate='optimal', loss='hinge', max_iter=10,\n" \
-                        "              n_iter_no_change=5, n_jobs=None, penalty='l2', power_t=0.5,\n" \
-                        "              random_state=112, shuffle=True, tol=0.001,\n" \
-                        "              validation_fraction=0.1, verbose=0, warm_start=False),\n" \
-                        "                order=None, random_state=112)"
-        assert learner.get_info() == expected_info
+        expected_info = "ClassifierChain(base_estimator=SGDClassifier(max_iter=10, " \
+                        "random_state=112), order=None, random_state=112)"
+        info = " ".join([line.strip() for line in learner.get_info().split()])
+        assert info == expected_info
 
     assert type(learner.predict(X)) == np.ndarray
 
@@ -103,22 +108,25 @@ def test_classifier_chains_all():
     assert type(cc.predict_proba(X)) == np.ndarray
 
     # RCC
-    rcc = ClassifierChain(SGDClassifier(max_iter=100, tol=1e-3, loss='log', random_state=seed), order='random',
-                          random_state=seed)
+    rcc = ClassifierChain(SGDClassifier(max_iter=100, tol=1e-3, loss='log', random_state=seed),
+                          order='random', random_state=seed)
     rcc.partial_fit(X, Y)
     y_predicted = rcc.predict(X)
     y_expected = [[1, 0, 1], [1, 1, 0], [0, 0, 0], [1, 1, 0]]
     assert np.alltrue(y_predicted == y_expected)
 
     # MCC
-    mcc = MonteCarloClassifierChain(SGDClassifier(max_iter=100, tol=1e-3, loss='log', random_state=seed), M=1000)
+    mcc = MonteCarloClassifierChain(SGDClassifier(max_iter=100, tol=1e-3, loss='log',
+                                                  random_state=seed),
+                                    M=1000)
     mcc.partial_fit(X, Y)
     y_predicted = mcc.predict(X)
     y_expected = [[1, 0, 1], [1, 1, 0], [0, 0, 0], [1, 1, 0]]
     assert np.alltrue(y_predicted == y_expected)
 
     # PCC
-    pcc = ProbabilisticClassifierChain(SGDClassifier(max_iter=100, tol=1e-3, loss='log', random_state=seed))
+    pcc = ProbabilisticClassifierChain(SGDClassifier(max_iter=100, tol=1e-3, loss='log',
+                                                     random_state=seed))
     pcc.partial_fit(X, Y)
     y_predicted = pcc.predict(X)
     y_expected = [[1, 0, 1], [1, 1, 0], [0, 0, 0], [1, 1, 0]]

--- a/tests/meta/test_learn_nse.py
+++ b/tests/meta/test_learn_nse.py
@@ -3,10 +3,16 @@ import numpy as np
 
 from sklearn.naive_bayes import GaussianNB
 from sklearn.tree import DecisionTreeClassifier
+from sklearn import set_config
+
 
 from skmultiflow.data import SEAGenerator, RandomTreeGenerator
 from skmultiflow.meta import LearnPPNSEClassifier
 from skmultiflow.trees import HoeffdingTreeClassifier
+
+# Force sklearn to show only the parameters whose default value have been changed when
+# printing an estimator (backwards compatibility with versions prior to sklearn==0.23)
+set_config(print_changed_only=True)
 
 
 def run_classifier(estimator, stream, pruning=None, ensemble_size=15, m=200):
@@ -63,10 +69,10 @@ def test_learn_nse():
     assert len(classifier.X_batch) == 0
     assert len(classifier.y_batch) == 0
 
-    expected_info = 'LearnPPNSEClassifier(base_estimator=GaussianNB(priors=None, var_smoothing=1e-09),\n' \
-                    '                     crossing_point=10, n_estimators=15, pruning=None,\n' \
-                    '                     slope=0.5, window_size=250)'
-    assert classifier.get_info() == expected_info
+    expected_info = 'LearnPPNSEClassifier(base_estimator=GaussianNB(), crossing_point=10, ' \
+                    'n_estimators=15, pruning=None, slope=0.5, window_size=250)'
+    info = " ".join([line.strip() for line in classifier.get_info().split()])
+    assert info == expected_info
     # test pruning error
     corrects, acc, classifier = run_classifier(estimator, stream, pruning="error", ensemble_size=5)
 

--- a/tests/meta/test_learn_pp.py
+++ b/tests/meta/test_learn_pp.py
@@ -1,14 +1,20 @@
 from skmultiflow.data import RandomTreeGenerator
 from skmultiflow.meta.learn_pp import LearnPPClassifier
 from sklearn.tree import DecisionTreeClassifier
+from sklearn import set_config
 import numpy as np
+
+# Force sklearn to show only the parameters whose default value have been changed when
+# printing an estimator (backwards compatibility with versions prior to sklearn==0.23)
+set_config(print_changed_only=True)
 
 
 def test_learn_pp():
     stream = RandomTreeGenerator(tree_random_state=2212, sample_random_state=2212)
 
     estimator = DecisionTreeClassifier(random_state=2212)
-    classifier = LearnPPClassifier(base_estimator=estimator, n_estimators=5, n_ensembles=5, random_state=2212)
+    classifier = LearnPPClassifier(base_estimator=estimator, n_estimators=5, n_ensembles=5,
+                                   random_state=2212)
 
     m = 200
 
@@ -42,11 +48,8 @@ def test_learn_pp():
     assert corrects == expected_correct_predictions
     assert type(classifier.predict(X)) == np.ndarray
 
-    expected_info = "LearnPPClassifier(base_estimator=DecisionTreeClassifier(ccp_alpha=0.0, " \
-                    "class_weight=None, criterion='gini', max_depth=None, max_features=None, max_leaf_nodes=None, " \
-                    "min_impurity_decrease=0.0, min_impurity_split=None, min_samples_leaf=1, " \
-                    "min_samples_split=2, min_weight_fraction_leaf=0.0, presort='deprecated', " \
-                    "random_state=2212, splitter='best'), error_threshold=0.5, n_ensembles=5, " \
+    expected_info = "LearnPPClassifier(base_estimator=DecisionTreeClassifier(" \
+                    "random_state=2212), error_threshold=0.5, n_ensembles=5, " \
                     "n_estimators=5, random_state=2212, window_size=100)"
     info = " ".join([line.strip() for line in classifier.get_info().split()])
     assert info == expected_info

--- a/tests/meta/test_multi_output_learner.py
+++ b/tests/meta/test_multi_output_learner.py
@@ -1,6 +1,7 @@
 from sklearn.linear_model import SGDClassifier, SGDRegressor
 from sklearn.metrics import mean_absolute_error
 from sklearn import __version__ as sklearn_version
+from sklearn import set_config
 
 from skmultiflow.meta.multi_output_learner import MultiOutputLearner
 from skmultiflow.data import MultilabelGenerator, RegressionGenerator
@@ -12,13 +13,18 @@ import pytest
 
 from distutils.version import LooseVersion
 
+# Force sklearn to show only the parameters whose default value have been changed when
+# printing an estimator (backwards compatibility with versions prior to sklearn==0.23)
+set_config(print_changed_only=True)
+
 
 @pytest.mark.filterwarnings('ignore::UserWarning')
 def test_multi_output_learner_classifier():
 
-    stream = MultilabelGenerator(n_samples=5150, n_features=15, n_targets=3, n_labels=4, random_state=112)
+    stream = MultilabelGenerator(n_samples=5150, n_features=15, n_targets=3, n_labels=4,
+                                 random_state=112)
 
-    estimator = SGDClassifier(random_state=112, tol=1e-3, max_iter=10, loss='log')
+    estimator = SGDClassifier(random_state=112, max_iter=10, loss='log')
     classifier = MultiOutputLearner(base_estimator=estimator)
 
     X, y = stream.next_sample(150)
@@ -44,16 +50,19 @@ def test_multi_output_learner_classifier():
         cnt += 1
 
     if LooseVersion(sklearn_version) < LooseVersion("0.21"):
-        expected_predictions = [[1.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0],
-                                [0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [0.0, 0.0, 1.0], [1.0, 1.0, 1.0], [0.0, 0.0, 1.0],
-                                [0.0, 1.0, 0.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0],
-                                [1.0, 0.0, 0.0], [0.0, 1.0, 1.0], [1.0, 0.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0],
-                                [0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0],
-                                [1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0],
-                                [0.0, 1.0, 0.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 0.0, 1.0],
-                                [0.0, 0.0, 1.0], [0.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 1.0],
-                                [0.0, 0.0, 1.0], [1.0, 1.0, 0.0], [1.0, 0.0, 1.0], [1.0, 0.0, 1.0], [0.0, 0.0, 1.0],
-                                [1.0, 1.0, 1.0], [0.0, 1.0, 0.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0]]
+        expected_predictions = [[1.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0],
+                                [1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [0.0, 0.0, 1.0],
+                                [1.0, 1.0, 1.0], [0.0, 0.0, 1.0], [0.0, 1.0, 0.0], [1.0, 1.0, 1.0],
+                                [0.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 0.0, 0.0],
+                                [0.0, 1.0, 1.0], [1.0, 0.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0],
+                                [0.0, 0.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0],
+                                [0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0],
+                                [0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 0.0], [0.0, 1.0, 1.0],
+                                [1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 0.0, 1.0], [0.0, 0.0, 1.0],
+                                [0.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 1.0],
+                                [0.0, 0.0, 1.0], [1.0, 1.0, 0.0], [1.0, 0.0, 1.0], [1.0, 0.0, 1.0],
+                                [0.0, 0.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 0.0], [1.0, 1.0, 1.0],
+                                [0.0, 1.0, 1.0]]
         assert np.alltrue(np.array_equal(predictions, expected_predictions))
 
         expected_correct_predictions = 26
@@ -63,26 +72,25 @@ def test_multi_output_learner_classifier():
         performance = hamming_score(true_labels, predictions)
         assert np.isclose(performance, expected_performance)
 
-        expected_info = "MultiOutputLearner(base_estimator=SGDClassifier(alpha=0.0001, average=False, " \
-                        "class_weight=None,\n" \
-                        "       early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True,\n" \
-                        "       l1_ratio=0.15, learning_rate='optimal', loss='log', max_iter=10,\n" \
-                        "       n_iter=None, n_iter_no_change=5, n_jobs=None, penalty='l2',\n" \
-                        "       power_t=0.5, random_state=112, shuffle=True, tol=0.001,\n" \
-                        "       validation_fraction=0.1, verbose=0, warm_start=False))"
-        assert classifier.get_info() == expected_info
+        expected_info = "MultiOutputLearner(base_estimator=SGDClassifier(loss='log', " \
+                        "random_state=112))"
+        info = " ".join([line.strip() for line in classifier.get_info().split()])
+        assert info == expected_info
 
     else:
-        expected_predictions = [[1.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0],
-                              [0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 0.0, 1.0], [1.0, 0.0, 1.0],
-                              [0.0, 1.0, 0.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0],
-                              [1.0, 1.0, 0.0], [1.0, 1.0, 1.0], [1.0, 0.0, 0.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0],
-                              [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0],
-                              [1.0, 1.0, 1.0], [0.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 1.0, 1.0], [1.0, 1.0, 0.0],
-                              [1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0],
-                              [1.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 1.0],
-                              [0.0, 0.0, 1.0], [1.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 0.0, 1.0], [0.0, 0.0, 1.0],
-                              [1.0, 1.0, 1.0], [1.0, 0.0, 0.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0]]
+        expected_predictions = [[1.0, 1.0, 1.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0],
+                                [1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 0.0, 1.0],
+                                [1.0, 0.0, 1.0], [1.0, 0.0, 1.0], [0.0, 1.0, 0.0], [1.0, 1.0, 1.0],
+                                [0.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 0.0],
+                                [1.0, 1.0, 1.0], [1.0, 0.0, 0.0], [1.0, 0.0, 1.0], [1.0, 1.0, 1.0],
+                                [1.0, 0.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 1.0, 1.0],
+                                [0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [0.0, 1.0, 0.0], [1.0, 0.0, 1.0],
+                                [0.0, 1.0, 1.0], [1.0, 1.0, 0.0], [1.0, 1.0, 1.0], [0.0, 1.0, 1.0],
+                                [1.0, 1.0, 1.0], [0.0, 1.0, 1.0], [1.0, 1.0, 1.0], [1.0, 0.0, 1.0],
+                                [0.0, 0.0, 1.0], [0.0, 0.0, 1.0], [1.0, 0.0, 0.0], [0.0, 1.0, 1.0],
+                                [0.0, 0.0, 1.0], [1.0, 1.0, 0.0], [1.0, 0.0, 1.0], [0.0, 0.0, 1.0],
+                                [0.0, 0.0, 1.0], [1.0, 1.0, 1.0], [1.0, 0.0, 0.0], [1.0, 1.0, 1.0],
+                                [0.0, 1.0, 1.0]]
         np.alltrue(np.array_equal(predictions, expected_predictions))
 
         expected_correct_predictions = 23
@@ -92,15 +100,11 @@ def test_multi_output_learner_classifier():
         performance = hamming_score(true_labels, predictions)
         assert np.isclose(performance, expected_performance)
 
-        expected_info = "MultiOutputLearner(base_estimator=SGDClassifier(alpha=0.0001, average=False, " \
-                        "class_weight=None,\n" \
-                        "              early_stopping=False, epsilon=0.1, eta0=0.0, fit_intercept=True,\n" \
-                        "              l1_ratio=0.15, learning_rate='optimal', loss='log', max_iter=10,\n" \
-                        "              n_iter_no_change=5, n_jobs=None, penalty='l2', power_t=0.5,\n" \
-                        "              random_state=112, shuffle=True, tol=0.001,\n" \
-                        "              validation_fraction=0.1, verbose=0, warm_start=False))"
+        expected_info = "MultiOutputLearner(base_estimator=SGDClassifier(loss='log', " \
+                        "max_iter=10, random_state=112))"
 
-        assert classifier.get_info() == expected_info
+        info = " ".join([line.strip() for line in classifier.get_info().split()])
+        assert info == expected_info
 
     assert type(classifier.predict(X)) == np.ndarray
     assert type(classifier.predict_proba(X)) == np.ndarray
@@ -109,7 +113,8 @@ def test_multi_output_learner_classifier():
 @pytest.mark.filterwarnings('ignore::UserWarning')
 def test_multi_output_learner_regressor():
 
-    stream = RegressionGenerator(n_samples=5500, n_features=10, n_informative=20, n_targets=2, random_state=1)
+    stream = RegressionGenerator(n_samples=5500, n_features=10, n_informative=20, n_targets=2,
+                                 random_state=1)
 
     estimator = SGDRegressor(random_state=112, tol=1e-3, max_iter=10, loss='squared_loss')
     learner = MultiOutputLearner(base_estimator=estimator)

--- a/tests/meta/test_regressor_chains.py
+++ b/tests/meta/test_regressor_chains.py
@@ -3,10 +3,15 @@ from skmultiflow.data import DataStream
 
 from skmultiflow.meta import RegressorChain
 from sklearn.linear_model import SGDRegressor
+from sklearn import set_config
 
 import numpy as np
 
 import pytest
+
+# Force sklearn to show only the parameters whose default value have been changed when
+# printing an estimator (backwards compatibility with versions prior to sklearn==0.23)
+set_config(print_changed_only=True)
 
 
 @pytest.mark.filterwarnings('ignore::UserWarning')
@@ -14,7 +19,7 @@ def test_regressor_chains():
     X_reg, y_reg = make_regression(random_state=112, n_targets=3, n_samples=5150)
     stream = DataStream(X_reg, y_reg)
 
-    estimator = SGDRegressor(random_state=112, max_iter=10, tol=1e-3)
+    estimator = SGDRegressor(random_state=112, max_iter=10)
     learner = RegressorChain(base_estimator=estimator, random_state=112)
 
     X, y = stream.next_sample(150)
@@ -90,23 +95,8 @@ def test_regressor_chains():
     assert np.allclose(np.array(predictions).all(), np.array(expected_predictions).all())
     assert type(learner.predict(X)) == np.ndarray
 
-    # sklearn < .0.21
-    expected_info_0 = "RegressorChain(base_estimator=SGDRegressor(alpha=0.0001, average=False, early_stopping=False, " \
-                      "epsilon=0.1,\n" \
-                      "       eta0=0.01, fit_intercept=True, l1_ratio=0.15,\n" \
-                      "       learning_rate='invscaling', loss='squared_loss', max_iter=10,\n" \
-                      "       n_iter=None, n_iter_no_change=5, penalty='l2', power_t=0.25,\n" \
-                      "       random_state=112, shuffle=True, tol=0.001, validation_fraction=0.1,\n" \
-                      "       verbose=0, warm_start=False),\n" \
-                      "               order=None, random_state=112)"
-    # sklearn >= .0.21
-    expected_info_1 = "RegressorChain(base_estimator=SGDRegressor(alpha=0.0001, average=False, early_stopping=False, " \
-                      "epsilon=0.1,\n" \
-                      "             eta0=0.01, fit_intercept=True, l1_ratio=0.15,\n" \
-                      "             learning_rate='invscaling', loss='squared_loss', max_iter=10,\n" \
-                      "             n_iter_no_change=5, penalty='l2', power_t=0.25, random_state=112,\n" \
-                      "             shuffle=True, tol=0.001, validation_fraction=0.1, verbose=0,\n" \
-                      "             warm_start=False),\n" \
-                      "               order=None, random_state=112)"
+    expected_info = "RegressorChain(base_estimator=SGDRegressor(max_iter=10, random_state=112), " \
+                    "order=None, random_state=112)"
 
-    assert learner.get_info() == expected_info_0 or learner.get_info() == expected_info_1
+    info = " ".join([line.strip() for line in learner.get_info().split()])
+    assert info == expected_info


### PR DESCRIPTION
With the recent release of `sklearn==0.23` some of the tests in our CI/CD pipeline have broken. This problem happened because of the following change in sklearn, which is stated in the new version's changelog:

![image](https://user-images.githubusercontent.com/9000157/82089865-ccb20380-96ca-11ea-8864-012515a737e6.png)

In simple terms, the string representation of a sklearn model only exhibits the parameters that were changed by the user, i.e., the ones that did not keep the suggested default values. 

Some of our automatic tests depend on sklearn and compare the skmultiflow models' descriptions with template strings. These strings previously depicted all the existing parameters of the sklearn models (which were usually used as base models for skmultiflow's meta models). This is no longer the case, as previously described.

We had two options:

1. Force sklearn to keep showing all the parameters and do not change the existing tests
2. Accept the new sklearn's behaviour and adapt our tests (ensuring backward compatibility with older versions of sklearn)

I opted to follow option 2 since it actually simplifies our tests and is future-proof (in case some parameters are renamed, for instance).

Changes proposed in this pull request:

* Fix broken CI/CD pipeline
* Enables support to `sklearn==0.23`
* Enforce PEP8 style formatting in the changed files

---

### Checklist
#### Implementation
- [ ] Implementation is correct (it performs its intended function).
- [ ] Code is consistent with the framework.
- [ ] Code is properly documented.
- [x] PR description covers ALL the changes performed.
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).

#### Tests
- [ ] New functionality is tested.
- [x] Tests are created for the new functionality or existing tests are updated accordingly.
- [x] ALL tests pass with no errors.
- [x] CI/CD pipelines run with no errors.
- [x] Test Coverage is maintained (coverage may drop by no more than 0.2%).
