### PR TITLE
Fix bug in BatchIncrementalClassifier

### DIFF
--- a/src/skmultiflow/meta/batch_incremental.py
+++ b/src/skmultiflow/meta/batch_incremental.py
@@ -108,7 +108,7 @@ class BatchIncrementalClassifier(BaseSKMObject, ClassifierMixin, MetaEstimatorMi
             # No models yet -- initialize
             self.X_batch = np.zeros((self.window_size, D))
             self.y_batch = np.zeros(self.window_size)
-            self.sample_weight = np.zeros(N)
+            self.sample_weight = np.zeros(self.window_size)
             self.i = 0
 
         for n in range(N):


### PR DESCRIPTION
Changes proposed in this pull request:

*  Fixes an error in `BatchIncrementalClassifier` when the first call to `partial_fit` contains fewer samples than `window_size`.

---

### Checklist
#### Implementation
- [x] Implementation is correct (it performs its intended function).
- [x] Code is consistent with the framework.
- [x] Code is properly documented.
- [x] PR description covers ALL the changes performed.
- [x] Files changed (update, add, delete) are in the PR's scope (no extra files are included).

#### Tests
- [ ] New functionality is tested.
- [ ] Tests are created for the new functionality or existing tests are updated accordingly.
- [x] ALL tests pass with no errors.
- [x] CI/CD pipelines run with no errors.
- [x] Test Coverage is maintained (coverage may drop by no more than 0.2%).
