### PR TITLE
Fix missing import in docstring example in multi_output_learner.py

### DIFF
--- a/src/skmultiflow/meta/multi_output_learner.py
+++ b/src/skmultiflow/meta/multi_output_learner.py
@@ -38,6 +38,7 @@ class MultiOutputLearner(BaseSKMObject, ClassifierMixin, MetaEstimatorMixin, Mul
     --------
     >>> from skmultiflow.meta.multi_output_learner import MultiOutputLearner
     >>> from skmultiflow.data.file_stream import FileStream
+    >>> from skmultiflow.metrics import hamming_score
     >>> from sklearn.linear_model import Perceptron
     >>> # Setup the file stream
     >>> stream = FileStream("https://raw.githubusercontent.com/scikit-multiflow/"


### PR DESCRIPTION
Changes proposed in this pull request:

*  add missing import in docstring example in `MultiOutputLearner`


---

### Checklist
#### Implementation
- [ x ] Implementation is correct (it performs its intended function).
- [ x ] Code is consistent with the framework.
- [ x ] Code is properly documented.
- [ x ] PR description covers ALL the changes performed.
- [ x ] Files changed (update, add, delete) are in the PR's scope (no extra files are included).

#### Tests
- [ ] New functionality is tested.
- [ ] Tests are created for the new functionality or existing tests are updated accordingly.
- [ ] ALL tests pass with no errors.
- [ ] CI/CD pipelines run with no errors.
- [ x ] Test Coverage is maintained (coverage may drop by no more than 0.2%).
