### PR TITLE
Fix sam_knn.py variable name for reset

### DIFF
--- a/src/skmultiflow/lazy/sam_knn.py
+++ b/src/skmultiflow/lazy/sam_knn.py
@@ -112,7 +112,7 @@ class SAMKNNClassifier(BaseSKMObject, ClassifierMixin):
         super().__init__()
         self.n_neighbors = n_neighbors
         self.weighting = weighting
-        self.max_wind_size = max_window_size
+        self.max_window_size = max_window_size
         self.ltm_size = ltm_size
         self.min_stm_size = min_stm_size
         self.use_ltm = use_ltm
@@ -122,8 +122,8 @@ class SAMKNNClassifier(BaseSKMObject, ClassifierMixin):
         self._STMLabels = np.empty(shape=(0), dtype=np.int32)
         self._LTMSamples = None
         self._LTMLabels = np.empty(shape=(0), dtype=np.int32)
-        self.maxLTMSize = self.ltm_size * self.max_wind_size
-        self.maxSTMSize = self.max_wind_size - self.maxLTMSize
+        self.maxLTMSize = self.ltm_size * self.max_window_size
+        self.maxSTMSize = self.max_window_size - self.maxLTMSize
         self.minSTMSize = self.min_stm_size
 
         if self.stm_size_option is not None:


### PR DESCRIPTION
As presented here, https://github.com/scikit-multiflow/scikit-multiflow/issues/272, `SAMKNNClassifier` cannot use the `reset()` method. This seems to be due to the name mismatch between internal variable `self.max_wind_size` and input argument `max_window_size`.

`max_wind_size` does not appear to be referenced anywhere else in the library, so simply editing the name to match `max_window_size` in `SAMKNNClassifier.__init__()` may be all the change that is needed to fix this.

<!-- 
Thank you for contributing with a PR!

Please fill the description of change(s) and/or indicate if it fixes an open issue (optional).

To ease the merge process please review the attached checklist.
-->

Changes proposed in this pull request:

* 
* Rename `max_wind_size` to `max_window_size` on all three uses in `SAMKNNClassifier.__init__()`.
* Fixes # 272

---

### Checklist
#### Implementation
- [x ] Implementation is correct (it performs its intended function).
- [x ] Code is consistent with the framework.
- [x ] Code is properly documented.
- [x ] PR description covers ALL the changes performed.
- [x ] Files changed (update, add, delete) are in the PR's scope (no extra files are included).

#### Tests
- [x ] New functionality is tested.
- [ ] Tests are created for the new functionality or existing tests are updated accordingly.
- [ ] ALL tests pass with no errors.
- [ ] CI/CD pipelines run with no errors.
- [ ] Test Coverage is maintained (coverage may drop by no more than 0.2%).
