### PR TITLE
Bugfix for issue #306 - [BUG] The change points detected are different from the points reported from MOA, using the same example #306

### DIFF
--- a/src/skmultiflow/drift_detection/adwin.py
+++ b/src/skmultiflow/drift_detection/adwin.py
@@ -187,6 +187,9 @@ class ADWIN(BaseDriftDetector):
         This function should be used at every new sample analysed.
 
         """
+        if self.in_concept_change:
+            self.reset()
+
         self._width += 1
         self.__insert_element_bucket(0, value, self.list_row_bucket.first)
         incremental_variance = 0
@@ -314,7 +317,7 @@ class ADWIN(BaseDriftDetector):
                 i = self.last_bucket_row
 
                 while (not bln_exit) and (cursor is not None):
-                    for k in range(cursor.bucket_size_row - 1):
+                    for k in range(cursor.bucket_size_row):
                         n2 = self.bucket_size(i)
                         u2 = cursor.get_total(k)
 

--- a/src/skmultiflow/drift_detection/adwin.py
+++ b/src/skmultiflow/drift_detection/adwin.py
@@ -187,7 +187,6 @@ class ADWIN(BaseDriftDetector):
         This function should be used at every new sample analysed.
 
         """
-
         if self.in_concept_change:
             self.reset()
 

--- a/src/skmultiflow/drift_detection/adwin.py
+++ b/src/skmultiflow/drift_detection/adwin.py
@@ -187,6 +187,7 @@ class ADWIN(BaseDriftDetector):
         This function should be used at every new sample analysed.
 
         """
+
         if self.in_concept_change:
             self.reset()
 

--- a/tests/drift_detection/test_adwin.py
+++ b/tests/drift_detection/test_adwin.py
@@ -13,7 +13,7 @@ def test_adwin(test_path):
     adwin = ADWIN()
     test_file = os.path.join(test_path, 'drift_stream.npy')
     data_stream = np.load(test_file)
-    expected_indices = [1023, 1055, 1087, 1151]
+    expected_indices = [1023]
     detected_indices = []
 
     for i in range(data_stream.size):


### PR DESCRIPTION
There are two differences comparing the MOA and scikit-multiflow implementation detected and fixed:
1)	When a concept drift is detected, the statistics should be reset. If not, the detector will continuously detect more drifts after the first detection. One example is the “drift_stream.npy” applied in the unit test. The stream contains one drift that starts at index 999 (the distribution of values changed). However, with the current implementation, four drifts are detected

With the current source code: 

![drift_stream npy](https://user-images.githubusercontent.com/5625088/160201087-33d3525b-01d7-40bc-8c2e-758ec3e53ce4.png)

After resetting the statistics on the add_element method:
 
![drift_stream_new_implementation](https://user-images.githubusercontent.com/5625088/172703667-b4c58d6f-af3c-438d-87d9-62750e59a872.png)

2)	In the method detected_change, the code does not iterate over the complete bucket because of this line:
`for k in range(cursor.bucket_size_row-1):`

I have changed the code line to solve it because the range function does not include the cursor value.bucket_size_row. New code line:
`for k in range(cursor.bucket_size_row):`


Changes proposed in this pull request:

* Change method add_element() from ADWIN class to reset statistics if a concept drift was detected.
* Change the method detected_change from ADWIN class to iterate the complete bucket.

---

### Checklist
#### Implementation
- [ ] Implementation is correct (it performs its intended function).
- [ ] Code is consistent with the framework.
- [ ] Code is properly documented.
- [ ] PR description covers ALL the changes performed.
- [ ] Files changed (update, add, delete) are in the PR's scope (no extra files are included).

#### Tests
- [X ] New functionality is tested.
- [X ] Tests are created for the new functionality or existing tests are updated accordingly.
- [X ] ALL tests pass with no errors.
- [ ] CI/CD pipelines run with no errors.
- [ ] Test Coverage is maintained (coverage may drop by no more than 0.2%).
