### PR TITLE
'FigureCanvasAgg' object has no attribute 'set_window_title'

### DIFF
--- a/src/skmultiflow/visualization/evaluation_visualizer.py
+++ b/src/skmultiflow/visualization/evaluation_visualizer.py
@@ -182,7 +182,7 @@ class EvaluationVisualizer(BaseListener):
         self.fig.suptitle(self.dataset_name)
         plot_metrics = [m for m in self.metrics if m not in [constants.RUNNING_TIME, constants.MODEL_SIZE]]
         base = 11 + len(plot_metrics) * 100  # 3-digit integer describing the position of the subplot.
-        self.fig.canvas.set_window_title('scikit-multiflow')
+
 
         # Subplots handler
         for metric_id in self.metrics:


### PR DESCRIPTION


This update requires as the attribute has been removed from FigureCanvasAgg object.



Changes proposed in this pull request:

* 
* 
* Fixes # [Optional]

---

### Checklist
#### Implementation
- [ ] Implementation is correct (it performs its intended function).
- [ ] Code is consistent with the framework.
- [ ] Code is properly documented.
- [ ] PR description covers ALL the changes performed.
- [ ] Files changed (update, add, delete) are in the PR's scope (no extra files are included).

#### Tests
- [ ] New functionality is tested.
- [ ] Tests are created for the new functionality or existing tests are updated accordingly.
- [ ] ALL tests pass with no errors.
- [ ] CI/CD pipelines run with no errors.
- [ ] Test Coverage is maintained (coverage may drop by no more than 0.2%).
